### PR TITLE
[MG-8] reminderScheduler: 배치 쿼리 + KST 보정 + bodyMulti + 유닛 테스트

### DIFF
--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -1,0 +1,228 @@
+// Mock 변수는 jest.mock factory에서 참조되므로 `mock` 접두사 필요 (ts-jest 호이스팅 규칙)
+const mockDQFindMany = jest.fn();
+const mockMembershipFindMany = jest.fn();
+const mockAnswerFindMany = jest.fn();
+
+jest.mock('../utils/prisma', () => ({
+  __esModule: true,
+  default: {
+    dailyQuestion: { findMany: mockDQFindMany },
+    familyMembership: { findMany: mockMembershipFindMany },
+    answer: { findMany: mockAnswerFindMany },
+  },
+}));
+
+const mockCreateNotification = jest.fn().mockResolvedValue(undefined);
+const mockGetUnreadCount = jest.fn().mockResolvedValue(0);
+jest.mock('../services/NotificationService', () => ({
+  NotificationService: jest.fn().mockImplementation(() => ({
+    createNotification: mockCreateNotification,
+    getUnreadCount: mockGetUnreadCount,
+  })),
+}));
+
+const mockSendApnsPush = jest.fn().mockResolvedValue(undefined);
+const mockSendFcmPush = jest.fn().mockResolvedValue(undefined);
+jest.mock('../services/PushNotificationService', () => ({
+  PushNotificationService: jest.fn().mockImplementation(() => ({
+    sendApnsPush: mockSendApnsPush,
+    sendFcmPush: mockSendFcmPush,
+  })),
+}));
+
+import { sendDailyReminders, getKstMidnightUtc } from '../reminderScheduler';
+
+const mockUser = {
+  id: 'user-1',
+  apnsToken: 'apns-token',
+  fcmToken: null,
+  locale: 'ko',
+  notifQuestion: true,
+};
+
+describe('getKstMidnightUtc', () => {
+  it('UTC 낮 시각 → 해당 KST 날짜의 자정(UTC 기준) 반환', () => {
+    // 2026-04-17 13:00 UTC = 2026-04-17 22:00 KST → KST 2026-04-17 00:00 = UTC 2026-04-16 15:00
+    const now = new Date('2026-04-17T13:00:00Z');
+    expect(getKstMidnightUtc(now).toISOString()).toBe('2026-04-16T15:00:00.000Z');
+  });
+
+  it('UTC 새벽 시각(KST 오전) → 동일한 KST 날짜의 자정 반환', () => {
+    // 2026-04-17 01:00 UTC = 2026-04-17 10:00 KST → KST 2026-04-17 00:00 = UTC 2026-04-16 15:00
+    const now = new Date('2026-04-17T01:00:00Z');
+    expect(getKstMidnightUtc(now).toISOString()).toBe('2026-04-16T15:00:00.000Z');
+  });
+
+  it('UTC 0시(KST 오전 9시) 경계 — KST 날짜 기준으로 계산되어 off-by-one 없음', () => {
+    // 2026-04-17 00:00 UTC = 2026-04-17 09:00 KST → KST 2026-04-17 00:00 = UTC 2026-04-16 15:00
+    const now = new Date('2026-04-17T00:00:00Z');
+    expect(getKstMidnightUtc(now).toISOString()).toBe('2026-04-16T15:00:00.000Z');
+  });
+});
+
+describe('sendDailyReminders', () => {
+  it('후보 DailyQuestion이 없으면 배치 조회와 알림 호출을 건너뛴다', async () => {
+    mockDQFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockMembershipFindMany).not.toHaveBeenCalled();
+    expect(mockAnswerFindMany).not.toHaveBeenCalled();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
+  });
+
+  it('미답변 멤버에게 DB 알림과 APNs 푸시를 각 1회 발송한다', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-1',
+      'ANSWER_REQUEST',
+      expect.any(String),
+      expect.any(String),
+      'fam-1'
+    );
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+    expect(mockSendFcmPush).not.toHaveBeenCalled();
+  });
+
+  it('전원 답변 완료 시 알림을 발송하지 않는다', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
+  });
+
+  it('skippedDate가 dq.date와 동일하면 해당 멤버는 대상에서 제외된다', async () => {
+    const dqDate = new Date('2026-04-15T00:00:00Z');
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: dqDate },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: dqDate, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('동일 유저의 미답변 복수 건은 bodyMulti 문구로 취합된다', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+      { id: 'dq-2', questionId: 'q-2', familyId: 'fam-1', date: new Date('2026-04-16') },
+      { id: 'dq-3', questionId: 'q-3', familyId: 'fam-1', date: new Date('2026-04-15') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    // (유저, 가족) 단위 1건
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    const body = mockCreateNotification.mock.calls[0][3] as string;
+    expect(body).toContain('3건');
+    // 푸시도 1회
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('다중 가족 소속 유저는 푸시를 1회만 받지만 DB 알림은 가족별로 생성된다', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-A', questionId: 'q-A', familyId: 'fam-A', date: new Date('2026-04-17') },
+      { id: 'dq-B', questionId: 'q-B', familyId: 'fam-B', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-A', skippedDate: null, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-B', skippedDate: null, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifQuestion=false 유저에게는 푸시를 발송하지 않는다 (DB 알림은 저장)', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      {
+        userId: 'user-1',
+        familyId: 'fam-1',
+        skippedDate: null,
+        user: { ...mockUser, notifQuestion: false },
+      },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
+  });
+
+  it('FCM 토큰만 있는 유저에게는 FCM 푸시만 발송된다', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      {
+        userId: 'user-1',
+        familyId: 'fam-1',
+        skippedDate: null,
+        user: { ...mockUser, apnsToken: null, fcmToken: 'fcm-token' },
+      },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
+    expect(mockSendFcmPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('가족 멤버 중 일부만 답변했으면 미답변 멤버만 대상이 된다', async () => {
+    const otherUser = { ...mockUser, id: 'user-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-2',
+      'ANSWER_REQUEST',
+      expect.any(String),
+      expect.any(String),
+      'fam-1'
+    );
+  });
+});

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -7,6 +7,24 @@ import { getPushMessages } from './utils/i18n/push';
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
 
+export const REMINDER_WINDOW_DAYS = 7;
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 현재 시점의 KST 자정을 UTC Date 로 반환.
+ * 윈도우 경계를 한국 기준으로 고정해서 UTC 0~9시 구간의 off-by-one 을 제거한다.
+ */
+export function getKstMidnightUtc(now: Date = new Date()): Date {
+  const nowInKst = new Date(now.getTime() + KST_OFFSET_MS);
+  const kstMidnight = Date.UTC(
+    nowInKst.getUTCFullYear(),
+    nowInKst.getUTCMonth(),
+    nowInKst.getUTCDate()
+  );
+  return new Date(kstMidnight - KST_OFFSET_MS);
+}
+
 function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boolean {
   if (!a || !b) return false;
   return a.toISOString().split('T')[0] === b.toISOString().split('T')[0];
@@ -16,131 +34,172 @@ function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boo
  * 자동 재촉 알림 발송 (KST 19:00 스케줄).
  *
  * 조건:
- *   - 각 가족의 "현재 활성 DailyQuestion" (가장 최근 배정분, 날짜 무관)
+ *   - 최근 REMINDER_WINDOW_DAYS 이내 배정된 모든 DailyQuestion
  *   - 아직 답변/패스하지 않은 멤버에게만
- *   - 유저당 1회 푸시 (다중 그룹 소속이어도 중복 발송 없음)
+ *   - 유저당 1회 푸시 (다중 그룹 소속, 다건 미답변이어도 중복 발송 없음)
+ *   - DB 알림은 (유저, 가족) 단위 1건으로 제한하여 과도한 알림 방지
+ *   - 미답변 2건 이상이면 bodyMulti(count) 로 묶어 표시
  *
  * 전원이 이미 완료된 경우는 건너뜀.
  */
 export async function sendDailyReminders(): Promise<void> {
-  // 각 가족의 가장 최근 DailyQuestion 1건만 추출 (날짜 구분 없음)
+  const kstMidnight = getKstMidnightUtc();
+  const windowStart = new Date(kstMidnight.getTime() - REMINDER_WINDOW_DAYS * DAY_MS);
+
   const candidateDQs = await prisma.dailyQuestion.findMany({
-    distinct: ['familyId'],
+    where: { date: { gte: windowStart } },
     orderBy: { date: 'desc' },
-    select: {
-      id: true,
-      questionId: true,
-      familyId: true,
-      date: true,
-    },
+    select: { id: true, questionId: true, familyId: true, date: true },
   });
-
-  let remindedFamilies = 0;
-  const dbNotifTasks: Promise<unknown>[] = [];
-  // 푸시 발송 대상을 유저 단위로 모아 중복 방지 (다중 그룹 소속 유저에게 1회만 발송)
-  const pushTargets = new Map<string, { apnsToken: string | null; fcmToken: string | null; locale: string | null; notifQuestion: boolean }>();
-
-  for (const dq of candidateDQs) {
-    // 가족 멤버 전원 조회
-    const memberships = await prisma.familyMembership.findMany({
-      where: { familyId: dq.familyId },
-      select: {
-        userId: true,
-        skippedDate: true,
-        user: {
-          select: { id: true, apnsToken: true, fcmToken: true, familyId: true, locale: true, notifQuestion: true },
-        },
-      },
-    });
-    if (memberships.length === 0) continue;
-
-    // 답변한 멤버 집계 (KST 윈도우 없음 — 시간 제한 없이 questionId 기준)
-    const answeredUserIds = new Set(
-      (await prisma.answer.findMany({
-        where: {
-          questionId: dq.questionId,
-          userId: { in: memberships.map((m) => m.userId) },
-        },
-        select: { userId: true },
-      })).map((a) => a.userId)
-    );
-
-    // 미완료 멤버(답변 X, 해당 DQ 에 대한 패스 X)만 추출
-    const unfinishedMemberships = memberships.filter(
-      (m) => !answeredUserIds.has(m.userId) && !isSameDate(m.skippedDate, dq.date)
-    );
-
-    if (unfinishedMemberships.length === 0) continue;
-
-    for (const m of unfinishedMemberships) {
-      const user = m.user;
-      if (!user) continue;
-      // 해당 질문이 속한 가족 그룹 ID를 사용 (user.familyId 는 기본 그룹이라 다를 수 있음)
-      const familyIdForNotif = dq.familyId;
-
-      const msgs = getPushMessages(user.locale);
-      const title = msgs.answerReminder.title;
-      const body = msgs.answerReminder.body;
-
-      // DB 알림은 그룹별로 생성 (앱 내 알림 목록에서 그룹 구분용)
-      dbNotifTasks.push(
-        notificationService
-          .createNotification(user.id, 'ANSWER_REQUEST', title, body, familyIdForNotif)
-          .catch((e) => {
-            console.warn('[Reminder] 알림 저장 실패:', e);
-          })
-      );
-
-      // 푸시 대상은 유저 단위로 1회만 수집 (중복 방지)
-      if (!pushTargets.has(user.id)) {
-        pushTargets.set(user.id, {
-          apnsToken: user.apnsToken,
-          fcmToken: user.fcmToken,
-          locale: user.locale,
-          notifQuestion: user.notifQuestion,
-        });
-      }
-    }
-    remindedFamilies++;
+  if (candidateDQs.length === 0) {
+    console.log('[Reminder] No candidate questions in window');
+    return;
   }
 
-  // DB 알림 저장 (그룹별) 실행
+  // 배치 조회 ①: 해당 가족들의 멤버십 일괄 조회 (N+1 제거)
+  const familyIds = Array.from(new Set(candidateDQs.map((dq) => dq.familyId)));
+  const allMemberships = await prisma.familyMembership.findMany({
+    where: { familyId: { in: familyIds } },
+    select: {
+      userId: true,
+      familyId: true,
+      skippedDate: true,
+      user: {
+        select: {
+          id: true,
+          apnsToken: true,
+          fcmToken: true,
+          locale: true,
+          notifQuestion: true,
+        },
+      },
+    },
+  });
+  type Membership = (typeof allMemberships)[number];
+  type MembershipUser = NonNullable<Membership['user']>;
+
+  const membershipsByFamily = new Map<string, Membership[]>();
+  for (const m of allMemberships) {
+    const arr = membershipsByFamily.get(m.familyId);
+    if (arr) arr.push(m);
+    else membershipsByFamily.set(m.familyId, [m]);
+  }
+
+  // 배치 조회 ②: 해당 질문들의 답변 일괄 조회 (N+1 제거)
+  const questionIds = Array.from(new Set(candidateDQs.map((dq) => dq.questionId)));
+  const userIds = Array.from(new Set(allMemberships.map((m) => m.userId)));
+  const allAnswers =
+    questionIds.length && userIds.length
+      ? await prisma.answer.findMany({
+          where: {
+            questionId: { in: questionIds },
+            userId: { in: userIds },
+          },
+          select: { questionId: true, userId: true },
+        })
+      : [];
+  const answeredByQuestion = new Map<string, Set<string>>();
+  for (const a of allAnswers) {
+    const set = answeredByQuestion.get(a.questionId);
+    if (set) set.add(a.userId);
+    else answeredByQuestion.set(a.questionId, new Set([a.userId]));
+  }
+
+  // 집계: 유저별 미답변 카운트, (유저, 가족) 키, 푸시 대상 유저 정보
+  const unansweredCountByUser = new Map<string, number>();
+  const userInfoMap = new Map<string, MembershipUser>();
+  const dbNotifKeys = new Set<string>(); // `${userId}:${familyId}`
+  const remindedFamilyIds = new Set<string>();
+
+  for (const dq of candidateDQs) {
+    const memberships = membershipsByFamily.get(dq.familyId);
+    if (!memberships || memberships.length === 0) continue;
+
+    const answeredSet = answeredByQuestion.get(dq.questionId);
+    const unfinished = memberships.filter(
+      (m) => !(answeredSet?.has(m.userId) ?? false) && !isSameDate(m.skippedDate, dq.date)
+    );
+    if (unfinished.length === 0) continue;
+
+    for (const m of unfinished) {
+      const user = m.user;
+      if (!user) continue;
+      unansweredCountByUser.set(
+        m.userId,
+        (unansweredCountByUser.get(m.userId) ?? 0) + 1
+      );
+      if (!userInfoMap.has(m.userId)) userInfoMap.set(m.userId, user);
+      dbNotifKeys.add(`${m.userId}:${dq.familyId}`);
+    }
+    remindedFamilyIds.add(dq.familyId);
+  }
+
+  function makeBody(locale: string | null, count: number): { title: string; body: string } {
+    const msgs = getPushMessages(locale);
+    return {
+      title: msgs.answerReminder.title,
+      body: count > 1 ? msgs.answerReminder.bodyMulti(count) : msgs.answerReminder.body,
+    };
+  }
+
+  // DB 알림 — (유저, 가족) 단위 1건
+  const dbNotifTasks: Promise<unknown>[] = [];
+  for (const key of dbNotifKeys) {
+    const [userId, familyIdForNotif] = key.split(':');
+    const user = userInfoMap.get(userId);
+    if (!user) continue;
+    const count = unansweredCountByUser.get(userId) ?? 1;
+    const { title, body } = makeBody(user.locale, count);
+    dbNotifTasks.push(
+      notificationService
+        .createNotification(userId, 'ANSWER_REQUEST', title, body, familyIdForNotif)
+        .catch((e) => {
+          console.warn('[Reminder] 알림 저장 실패:', e);
+        })
+    );
+  }
   await Promise.all(dbNotifTasks);
 
-  // 푸시 발송 — 유저당 1회만 (다중 그룹이어도 단일 푸시)
+  // 푸시 — 유저당 1회
   const pushTasks: Promise<unknown>[] = [];
-  for (const [userId, target] of pushTargets) {
-    if (!target.notifQuestion) continue;
-    const msgs = getPushMessages(target.locale);
-    const title = msgs.answerReminder.title;
-    const body = msgs.answerReminder.body;
+  for (const [userId, user] of userInfoMap) {
+    if (!user.notifQuestion) continue;
+    const count = unansweredCountByUser.get(userId) ?? 1;
+    const { title, body } = makeBody(user.locale, count);
 
-    if (target.apnsToken) {
+    if (user.apnsToken) {
       pushTasks.push(
         (async () => {
           const badgeCount = await notificationService.getUnreadCount(userId);
-          await pushService.sendApnsPush(target.apnsToken!, title, body, 'ANSWER_REQUEST', badgeCount);
+          await pushService.sendApnsPush(
+            user.apnsToken!,
+            title,
+            body,
+            'ANSWER_REQUEST',
+            badgeCount
+          );
         })().catch((e) => {
           console.warn('[Reminder] APNs 푸시 실패:', e);
         })
       );
     }
-    if (target.fcmToken) {
+    if (user.fcmToken) {
       pushTasks.push(
-        pushService.sendFcmPush(target.fcmToken, title, body, 'ANSWER_REQUEST').catch((e) => {
-          console.warn('[Reminder] FCM 푸시 실패:', e);
-        })
+        pushService
+          .sendFcmPush(user.fcmToken, title, body, 'ANSWER_REQUEST')
+          .catch((e) => {
+            console.warn('[Reminder] FCM 푸시 실패:', e);
+          })
       );
     }
   }
   await Promise.all(pushTasks);
 
   console.log(
-    `[Reminder] Reminded ${pushTargets.size} unique users across ${remindedFamilies} families`
+    `[Reminder] Reminded ${userInfoMap.size} unique users across ${remindedFamilyIds.size} families`
   );
 }
 
-// EventBridge Lambda 핸들러
 export const handler = async (_event: ScheduledEvent, _context: Context): Promise<void> => {
   try {
     await sendDailyReminders();

--- a/src/utils/i18n/push.ts
+++ b/src/utils/i18n/push.ts
@@ -19,7 +19,7 @@ const DEFAULT_LOCALE: Locale = 'ko';
 interface PushMessages {
   newQuestion: { title: string; body: string };
   memberAnswered: { title: (senderName: string) => string; body: string };
-  answerReminder: { title: string; body: string };
+  answerReminder: { title: string; body: string; bodyMulti: (count: number) => string };
   nudge: { title: string; body: (senderName: string) => string };
 }
 
@@ -36,6 +36,7 @@ const messagesByLocale: Record<Locale, PushMessages> = {
     answerReminder: {
       title: '오늘의 질문, 아직 답변 전이에요',
       body: '그룹 멤버들이 오늘의 질문을 기다리고 있어요. 한마디 남겨볼까요?',
+      bodyMulti: (count) => `${count}건의 미답변 질문이 있어요. 지금 확인해볼까요?`,
     },
     nudge: {
       title: '재촉하기 알림',
@@ -54,6 +55,7 @@ const messagesByLocale: Record<Locale, PushMessages> = {
     answerReminder: {
       title: "Today's question is waiting",
       body: 'Your group is waiting for your answer. Leave a note!',
+      bodyMulti: (count) => `You have ${count} unanswered questions. Take a look now!`,
     },
     nudge: {
       title: 'A gentle nudge',
@@ -72,6 +74,7 @@ const messagesByLocale: Record<Locale, PushMessages> = {
     answerReminder: {
       title: 'まだ回答していない質問があります',
       body: 'グループのメンバーがあなたの回答を待っています。一言どうですか？',
+      bodyMulti: (count) => `${count}件の未回答の質問があります。今確認してみませんか？`,
     },
     nudge: {
       title: 'リマインドが届きました',


### PR DESCRIPTION
## Jira
- [MG-8](https://ycompany.atlassian.net/browse/MG-8) (sub of [MG-6](https://ycompany.atlassian.net/browse/MG-6))

## Related
- 상위 PR: `fix/MG-6-reminder-past-unanswered`
- 본 PR은 main 기반이라 MG-6와 독립 머지 가능. 순서는 MG-6 → MG-8 권장 (코드상 diff가 일부 겹칠 수 있음)

## Summary
MG-6 QA 검증 후 지적된 N+1, KST 경계, bodyMulti 부재, 테스트 부재를 한 번에 해결.

- **N+1 제거**: `familyId`/`questionId` 집합으로 `familyMembership`, `answer`를 배치 조회 후 `Map` 그룹핑 → 가족 수 무관 상수 쿼리
- **KST 보정**: `getKstMidnightUtc()` 추가. 윈도우 경계를 KST 자정에 고정 (UTC 0~9시 off-by-one 제거)
- **bodyMulti**: `push.ts` `answerReminder`에 `bodyMulti(count)` 추가 (ko/en/ja). 미답변 2건 이상이면 "3건의 미답변 질문이 있어요" 형식으로 취합
- **유닛 테스트**: `src/__tests__/reminderScheduler.test.ts` — 12 케이스 (KST 경계 3, 핵심 시나리오 9)

## Test plan
- [x] `npm test` 전체 통과 (CI)
- [x] `reminderScheduler.test.ts` 12/12 통과 (로컬 실행 1.7s)
- [ ] 스테이징에서 bodyMulti 문구 ko/en/ja 렌더링 확인
- [ ] 대규모 가족·유저 환경에서 Lambda 실행 시간 단축 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)