### PR TITLE
[MG-10] 서비스 레이어 유닛 테스트 회귀 17건 복구

### DIFF
--- a/src/services/__tests__/AnswerService.test.ts
+++ b/src/services/__tests__/AnswerService.test.ts
@@ -1,18 +1,30 @@
+// ---- Prisma mock ----
 const mockPrismaUserFindUnique = jest.fn();
+const mockPrismaUserFindMany = jest.fn();
 const mockPrismaQuestionFindUnique = jest.fn();
 const mockPrismaAnswerFindUnique = jest.fn();
 const mockPrismaAnswerCreate = jest.fn();
 const mockPrismaAnswerFindMany = jest.fn();
 const mockPrismaAnswerUpdate = jest.fn();
 const mockPrismaAnswerDelete = jest.fn();
+const mockPrismaFamilyMembershipFindUnique = jest.fn();
 const mockPrismaFamilyMembershipFindMany = jest.fn();
 const mockPrismaFamilyMembershipUpdateMany = jest.fn();
+const mockPrismaDailyQuestionFindFirst = jest.fn();
+// $transaction 은 ops 배열을 받아 각각을 await 하는 형태, 또는 콜백 형태를 둘 다 지원한다.
+const mockPrismaTransaction = jest.fn().mockImplementation(async (arg: unknown) => {
+  if (Array.isArray(arg)) return Promise.all(arg as Promise<unknown>[]);
+  if (typeof arg === 'function') return (arg as (tx: unknown) => Promise<unknown>)({});
+  return arg;
+});
 
 jest.mock('../../utils/prisma', () => ({
   __esModule: true,
   default: {
+    $transaction: mockPrismaTransaction,
     user: {
       findUnique: mockPrismaUserFindUnique,
+      findMany: mockPrismaUserFindMany,
     },
     question: {
       findUnique: mockPrismaQuestionFindUnique,
@@ -25,10 +37,37 @@ jest.mock('../../utils/prisma', () => ({
       delete: mockPrismaAnswerDelete,
     },
     familyMembership: {
+      findUnique: mockPrismaFamilyMembershipFindUnique,
       findMany: mockPrismaFamilyMembershipFindMany,
       updateMany: mockPrismaFamilyMembershipUpdateMany,
     },
+    dailyQuestion: {
+      findFirst: mockPrismaDailyQuestionFindFirst,
+    },
   },
+}));
+
+// ---- 외부 서비스 / helper mock ----
+const mockCreateNotification = jest.fn().mockResolvedValue(undefined);
+const mockGetUnreadCount = jest.fn().mockResolvedValue(0);
+jest.mock('../NotificationService', () => ({
+  NotificationService: jest.fn().mockImplementation(() => ({
+    createNotification: mockCreateNotification,
+    getUnreadCount: mockGetUnreadCount,
+  })),
+}));
+
+const mockSendApnsPush = jest.fn().mockResolvedValue(undefined);
+const mockSendFcmPush = jest.fn().mockResolvedValue(undefined);
+jest.mock('../PushNotificationService', () => ({
+  PushNotificationService: jest.fn().mockImplementation(() => ({
+    sendApnsPush: mockSendApnsPush,
+    sendFcmPush: mockSendFcmPush,
+  })),
+}));
+
+jest.mock('../dailyQuestionCompletion', () => ({
+  tryFinalizeDailyQuestion: jest.fn().mockResolvedValue(undefined),
 }));
 
 import { AnswerService } from '../AnswerService';
@@ -77,6 +116,13 @@ const mockAnswerWithUser = {
   },
 };
 
+// createAnswer 가 성공 경로로 흘러갈 때 필요한 후속 호출들을 미리 세팅
+function setupCreateAnswerSuccessPath() {
+  mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id' });
+  mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ nickname: null, colorId: 'loved' });
+  mockPrismaUserFindMany.mockResolvedValue([]); // 다른 가족 멤버 없음 → 알림/푸시 루프 생략
+}
+
 describe('AnswerService.createAnswer', () => {
   it('존재하지 않는 유저는 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(null);
@@ -96,6 +142,7 @@ describe('AnswerService.createAnswer', () => {
   it('이미 답변한 질문에 다시 답변하면 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaQuestionFindUnique.mockResolvedValue(mockQuestion);
+    mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id' });
     mockPrismaAnswerFindUnique.mockResolvedValue(mockAnswerWithUser); // 이미 답변 존재
 
     await expect(
@@ -106,15 +153,16 @@ describe('AnswerService.createAnswer', () => {
   it('답변 성공 시 하트가 +1 증가한다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaQuestionFindUnique.mockResolvedValue(mockQuestion);
-    mockPrismaAnswerFindUnique.mockResolvedValue(null); // 미답변
+    mockPrismaAnswerFindUnique.mockResolvedValue(null);
     mockPrismaAnswerCreate.mockResolvedValue(mockAnswerWithUser);
     mockPrismaFamilyMembershipUpdateMany.mockResolvedValue({ count: 1 });
+    setupCreateAnswerSuccessPath();
 
     await service.createAnswer('kakao:123', { questionId: 'question-id', content: '답변' });
 
     expect(mockPrismaFamilyMembershipUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { hearts: { increment: 1 } },
+        data: expect.objectContaining({ hearts: { increment: 1 } }),
       })
     );
   });
@@ -137,6 +185,7 @@ describe('AnswerService.createAnswer', () => {
     mockPrismaAnswerFindUnique.mockResolvedValue(null);
     mockPrismaAnswerCreate.mockResolvedValue(mockAnswerWithUser);
     mockPrismaFamilyMembershipUpdateMany.mockResolvedValue({ count: 1 });
+    setupCreateAnswerSuccessPath();
 
     await service.createAnswer('kakao:123', { questionId: 'QUESTION-ID-UPPER', content: '답변' });
 
@@ -189,7 +238,7 @@ describe('AnswerService.getFamilyAnswers', () => {
   it('가족 멤버들의 답변 목록을 반환한다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaFamilyMembershipFindMany.mockResolvedValue([
-      { userId: 'db-user-id', nickname: '아빠', user: { name: '테스트' } },
+      { userId: 'db-user-id', nickname: '아빠', colorId: 'calm', user: { name: '테스트', moodId: null } },
     ]);
     mockPrismaAnswerFindMany.mockResolvedValue([mockAnswerWithUser]);
 
@@ -202,7 +251,7 @@ describe('AnswerService.getFamilyAnswers', () => {
   it('닉네임이 있으면 이름 대신 닉네임을 사용한다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaFamilyMembershipFindMany.mockResolvedValue([
-      { userId: 'db-user-id', nickname: '우리아빠', user: { name: '테스트' } },
+      { userId: 'db-user-id', nickname: '우리아빠', colorId: 'calm', user: { name: '테스트', moodId: null } },
     ]);
     mockPrismaAnswerFindMany.mockResolvedValue([mockAnswerWithUser]);
 

--- a/src/services/__tests__/AuthService.test.ts
+++ b/src/services/__tests__/AuthService.test.ts
@@ -71,6 +71,7 @@ describe('AuthService.refreshToken', () => {
     mockVerifyRefreshToken.mockReturnValue({ sub: 'deleted-user', email: 'gone@test.com' });
     mockUserFindUnique.mockResolvedValue(null);
 
-    await expect(service.refreshToken('orphan-token')).rejects.toThrow('사용자를 찾을 수 없습니다.');
+    // ApiError 가 조사 처리(을/를)를 자동 변형하므로 정확 일치 대신 핵심 토큰으로 검증
+    await expect(service.refreshToken('orphan-token')).rejects.toThrow(/사용자.+찾을 수 없습니다/);
   });
 });

--- a/src/services/__tests__/FamilyService.test.ts
+++ b/src/services/__tests__/FamilyService.test.ts
@@ -184,9 +184,9 @@ describe('FamilyService.leaveFamily', () => {
     await expect(service.leaveFamily('unknown')).rejects.toThrow();
   });
 
-  it('가족에 속해 있지 않으면 에러를 던진다', async () => {
+  it('그룹에 속해 있지 않으면 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue({ ...mockUser, familyId: null });
-    await expect(service.leaveFamily('kakao:123')).rejects.toThrow('가족에 속해 있지 않습니다.');
+    await expect(service.leaveFamily('kakao:123')).rejects.toThrow('그룹에 속해 있지 않습니다.');
   });
 
   it('방장이고 다른 멤버가 있으면 에러를 던진다', async () => {
@@ -197,7 +197,7 @@ describe('FamilyService.leaveFamily', () => {
     mockPrismaFamilyFindUnique.mockResolvedValue({ ...mockFamily, createdById: 'db-user-id' });
     mockPrismaFamilyMembershipCount.mockResolvedValue(2); // 2명
 
-    await expect(service.leaveFamily('kakao:123')).rejects.toThrow('가족 생성자는 가족을 떠날 수 없습니다.');
+    await expect(service.leaveFamily('kakao:123')).rejects.toThrow('그룹 생성자는 그룹을 떠날 수 없습니다.');
   });
 
   it('방장이고 혼자이면 가족이 삭제된다', async () => {

--- a/src/services/__tests__/QuestionService.test.ts
+++ b/src/services/__tests__/QuestionService.test.ts
@@ -7,6 +7,7 @@ const mockPrismaQuestionFindUnique = jest.fn();
 const mockPrismaQuestionFindMany = jest.fn();
 const mockPrismaQuestionCreate = jest.fn();
 const mockPrismaDailyQuestionFindUnique = jest.fn();
+const mockPrismaDailyQuestionFindFirst = jest.fn();
 const mockPrismaDailyQuestionFindMany = jest.fn();
 const mockPrismaDailyQuestionCreate = jest.fn();
 const mockPrismaDailyQuestionUpdate = jest.fn();
@@ -36,6 +37,7 @@ jest.mock('../../utils/prisma', () => ({
     },
     dailyQuestion: {
       findUnique: mockPrismaDailyQuestionFindUnique,
+      findFirst: mockPrismaDailyQuestionFindFirst,
       findMany: mockPrismaDailyQuestionFindMany,
       create: mockPrismaDailyQuestionCreate,
       update: mockPrismaDailyQuestionUpdate,
@@ -64,6 +66,9 @@ const mockMembership = {
   familyId: 'family-id',
   hearts: 5,
   skippedDate: null,
+  nickname: null as string | null,
+  colorId: 'loved',
+  user: { name: '테스트', moodId: null },
 };
 
 const mockQuestion = {
@@ -108,7 +113,7 @@ describe('QuestionService.getTodayQuestion', () => {
 
   it('가족에 속하지 않은 유저는 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue({ ...mockUser, familyId: null });
-    await expect(service.getTodayQuestion('kakao:123')).rejects.toThrow('가족에 속해 있지 않습니다.');
+    await expect(service.getTodayQuestion('kakao:123')).rejects.toThrow('그룹에 속해 있지 않습니다.');
   });
 
   it('오늘 질문이 이미 있으면 새로 배정하지 않는다', async () => {
@@ -142,7 +147,7 @@ describe('QuestionService.skipTodayQuestion', () => {
 
   it('가족에 속하지 않은 유저는 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue({ ...mockUser, familyId: null });
-    await expect(service.skipTodayQuestion('kakao:123')).rejects.toThrow('가족에 속해 있지 않습니다.');
+    await expect(service.skipTodayQuestion('kakao:123')).rejects.toThrow('그룹에 속해 있지 않습니다.');
   });
 
   it('멤버십이 없으면 에러를 던진다', async () => {
@@ -153,19 +158,21 @@ describe('QuestionService.skipTodayQuestion', () => {
 
   it('하트가 부족하면 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
+    mockPrismaDailyQuestionFindUnique.mockResolvedValue(mockDailyQuestion); // 오늘 질문 존재
     mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ ...mockMembership, hearts: 2 });
     await expect(service.skipTodayQuestion('kakao:123')).rejects.toThrow('하트가 부족합니다');
   });
 
-  it('이미 오늘 패스한 경우 에러를 던진다', async () => {
+  it('이미 해당 질문을 패스한 경우 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
-    const today = new Date(new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' }) + 'T00:00:00.000Z');
+    const questionDate = mockDailyQuestion.date;
+    mockPrismaDailyQuestionFindUnique.mockResolvedValue(mockDailyQuestion);
     mockPrismaFamilyMembershipFindUnique.mockResolvedValue({
       ...mockMembership,
       hearts: 5,
-      skippedDate: today,
+      skippedDate: questionDate, // 이미 같은 날짜에 패스
     });
-    await expect(service.skipTodayQuestion('kakao:123')).rejects.toThrow('오늘 이미 질문을 패스했습니다');
+    await expect(service.skipTodayQuestion('kakao:123')).rejects.toThrow('이미 질문을 패스했습니다');
   });
 
   it('이미 답변한 경우 패스할 수 없다', async () => {
@@ -230,7 +237,7 @@ describe('QuestionService.createCustomQuestion', () => {
     mockPrismaFamilyMembershipFindMany.mockResolvedValue([{ userId: 'db-user-id' }]);
     mockPrismaAnswerCount.mockResolvedValue(1); // 이미 답변 있음
 
-    await expect(service.createCustomQuestion('kakao:123', '새 질문')).rejects.toThrow('이미 가족 중 누군가가 답변했습니다.');
+    await expect(service.createCustomQuestion('kakao:123', '새 질문')).rejects.toThrow('이미 그룹 멤버 중 누군가가 답변했습니다.');
   });
 
   it('빈 내용은 에러를 던진다', async () => {
@@ -282,5 +289,7 @@ describe('QuestionService.createCustomQuestion', () => {
 function setupToDailyQuestionResponseMocks() {
   mockPrismaUserFindMany.mockResolvedValue([{ id: 'db-user-id' }]);
   mockPrismaFamilyMembershipFindUnique.mockResolvedValue(mockMembership);
+  // toDailyQuestionResponse 에서 findMany 로 멤버 전원을 select user.name 까지 포함하여 조회
+  mockPrismaFamilyMembershipFindMany.mockResolvedValue([mockMembership]);
   mockPrismaAnswerFindMany.mockResolvedValue([]);
 }


### PR DESCRIPTION
## Jira
- [MG-10](https://ycompany.atlassian.net/browse/MG-10)

## Summary
main 브랜치에서 누적된 테스트 회귀 17건(4개 suite)을 복구. 프로덕션 로직은 변경 없음, 테스트 코드만 최신 구현에 맞춰 보완.

- 문구 리네이밍 반영 ("가족" → "그룹" / "그룹 멤버")
- Prisma mock 확장 (`dailyQuestion.findFirst`, `$transaction`, `user.findMany`)
- mock 데이터 구조 보강 (`user.name`, `nickname`, `colorId`)
- 외부 서비스 mock 추가 (`NotificationService`, `PushNotificationService`, `tryFinalizeDailyQuestion`)

## Test plan
- [x] `npm test` 전체 통과 — **86/86** (7 suites, 4.98s)
- [x] 프로덕션 로직 미변경 확인 (테스트 파일만 수정)
- [ ] (후속 권장) `.github/workflows/test.yml` 추가 — 재발 방지

## 주의
- 배포 불필요 (테스트 전용 변경)
- 이전에 머지된 MG-6, MG-8 브랜치와 코드상 충돌 없음

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)