### PR TITLE
feat(reminder): 답변자에게 가족 미답변 알림 (MG-12)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   notifAnswer            Boolean   @default(true)  @map("notif_answer")    // 구성원 답변 알림
   notifNudge             Boolean   @default(true)  @map("notif_nudge")     // 재촉하기 알림
   notifQuestion          Boolean   @default(true)  @map("notif_question")  // 새 질문 알림
+  notifAnswererNudge     Boolean   @default(true)  @map("notif_answerer_nudge") // 내가 답변 후 가족 미답변 알림
   quietHoursEnabled      Boolean   @default(true)  @map("quiet_hours_enabled")
   quietHoursStart        String    @default("22:00") @map("quiet_hours_start")
   quietHoursEnd          String    @default("08:00") @map("quiet_hours_end")
@@ -203,5 +204,6 @@ enum NotificationType {
   MEMBER_ANSWERED
   ALL_ANSWERED
   ANSWER_REQUEST
+  ANSWERER_NUDGE
   BADGE_EARNED
 }

--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -38,6 +38,7 @@ const mockUser = {
   fcmToken: null,
   locale: 'ko',
   notifQuestion: true,
+  notifAnswererNudge: true,
 };
 
 describe('getKstMidnightUtc', () => {
@@ -216,7 +217,8 @@ describe('sendDailyReminders', () => {
 
     await sendDailyReminders();
 
-    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    // user-2(미답변)에게 ANSWER_REQUEST 1건 + user-1(답변자)에게 ANSWERER_NUDGE 1건 = 총 2건
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
     expect(mockCreateNotification).toHaveBeenCalledWith(
       'user-2',
       'ANSWER_REQUEST',
@@ -224,5 +226,158 @@ describe('sendDailyReminders', () => {
       expect.any(String),
       'fam-1'
     );
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-1',
+      'ANSWERER_NUDGE',
+      expect.any(String),
+      expect.any(String),
+      'fam-1'
+    );
+  });
+});
+
+describe('sendDailyReminders - answerer nudge (MG-12)', () => {
+  it('본인 답변 + 가족 1명 미답변 → 답변자에게 ANSWERER_NUDGE DB/푸시 1회', async () => {
+    const otherUser = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    const nudgeCalls = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeCalls).toHaveLength(1);
+    expect(nudgeCalls[0][0]).toBe('user-1');
+    // body 에 "1명" 포함 (pendingCount=1)
+    expect(nudgeCalls[0][3]).toContain('1명');
+
+    // APNs 푸시: user-1(답변자) + user-2(미답변) 각 1회 = 2회
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(2);
+    const apnsCallsAnswerer = mockSendApnsPush.mock.calls.filter(
+      (c) => c[3] === 'ANSWERER_NUDGE'
+    );
+    expect(apnsCallsAnswerer).toHaveLength(1);
+  });
+
+  it('전원 답변 완료 → 답변자 재촉 발송 안 함', async () => {
+    const otherUser = { ...mockUser, id: 'user-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([
+      { questionId: 'q-1', userId: 'user-1' },
+      { questionId: 'q-1', userId: 'user-2' },
+    ]);
+
+    await sendDailyReminders();
+
+    const nudgeCalls = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeCalls).toHaveLength(0);
+  });
+
+  it('1인 가족 → 답변자 재촉 발송 안 함 (멤버십 1명 스킵)', async () => {
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    const nudgeCalls = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeCalls).toHaveLength(0);
+  });
+
+  it('notifAnswererNudge=false 유저는 푸시 제외 (DB 알림은 저장)', async () => {
+    const optedOutUser = { ...mockUser, notifAnswererNudge: false };
+    const otherUser = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: optedOutUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    const nudgeDb = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeDb).toHaveLength(1); // DB 알림은 저장
+
+    const nudgeApns = mockSendApnsPush.mock.calls.filter(
+      (c) => c[3] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeApns).toHaveLength(0); // 푸시는 제외
+  });
+
+  it('4일 윈도우 밖 DQ(5일 전)는 답변자 재촉 대상에서 제외', async () => {
+    const otherUser = { ...mockUser, id: 'user-2' };
+    // 오늘 = now — mock 기준일 없음. REMINDER_WINDOW_DAYS=7 이므로 DQ 5일 전이 7일 윈도우엔 들어옴
+    // 그러나 ANSWERER_NUDGE_WINDOW_DAYS=4 이므로 답변자 재촉 대상에선 빠져야 함
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-old', questionId: 'q-old', familyId: 'fam-1', date: fiveDaysAgo },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-old', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    const nudgeCalls = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeCalls).toHaveLength(0);
+  });
+
+  it('답변자가 복수 질문에서 가족 미답변 상태면 bodyMulti 문구 사용', async () => {
+    const otherUser = { ...mockUser, id: 'user-2' };
+    const today = new Date();
+    const y1 = new Date(today.getTime() - 1 * 24 * 60 * 60 * 1000);
+    const y2 = new Date(today.getTime() - 2 * 24 * 60 * 60 * 1000);
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: today },
+      { id: 'dq-2', questionId: 'q-2', familyId: 'fam-1', date: y1 },
+      { id: 'dq-3', questionId: 'q-3', familyId: 'fam-1', date: y2 },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([
+      { questionId: 'q-1', userId: 'user-1' },
+      { questionId: 'q-2', userId: 'user-1' },
+      { questionId: 'q-3', userId: 'user-1' },
+    ]);
+
+    await sendDailyReminders();
+
+    const nudgeCalls = mockCreateNotification.mock.calls.filter(
+      (c) => c[1] === 'ANSWERER_NUDGE'
+    );
+    expect(nudgeCalls).toHaveLength(1); // (user-1, fam-1) 단위 1건
+    expect(nudgeCalls[0][3]).toContain('3개'); // 3개 질문
   });
 });

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -8,6 +8,7 @@ const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
 
 export const REMINDER_WINDOW_DAYS = 7;
+export const ANSWERER_NUDGE_WINDOW_DAYS = 4;
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -56,6 +57,11 @@ export async function sendDailyReminders(): Promise<void> {
     return;
   }
 
+  // 답변자 재촉(answerer nudge) 윈도우는 미답변 재촉보다 짧음 (기본 4일 = 오늘+과거 3일)
+  const answererNudgeWindowStart = new Date(
+    kstMidnight.getTime() - ANSWERER_NUDGE_WINDOW_DAYS * DAY_MS
+  );
+
   // 배치 조회 ①: 해당 가족들의 멤버십 일괄 조회 (N+1 제거)
   const familyIds = Array.from(new Set(candidateDQs.map((dq) => dq.familyId)));
   const allMemberships = await prisma.familyMembership.findMany({
@@ -71,6 +77,7 @@ export async function sendDailyReminders(): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
+          notifAnswererNudge: true,
         },
       },
     },
@@ -197,6 +204,127 @@ export async function sendDailyReminders(): Promise<void> {
 
   console.log(
     `[Reminder] Reminded ${userInfoMap.size} unique users across ${remindedFamilyIds.size} families`
+  );
+
+  // ────────────────────────────────────────────────────────────
+  // MG-12: 답변자 재촉(answerer nudge)
+  //   - 본인은 답변 완료 + 같은 가족 중 최소 1명 미답변
+  //   - 4일 윈도우(오늘+과거 3일). 미답변 재촉(7일)보다 짧게 → 알림 피로 감소
+  //   - 푸시는 유저당 1회, DB 알림은 (유저, 가족) 단위
+  // ────────────────────────────────────────────────────────────
+
+  // 답변자별 집계: 몇 개 질문에서 가족 미답변 상태로 남았는지(questionCount), 총 몇 명 대기 중(pendingMembers)
+  const answererQuestionCount = new Map<string, number>();
+  const answererPendingCount = new Map<string, number>();
+  const answererUserMap = new Map<string, MembershipUser>();
+  const answererDbKeys = new Set<string>(); // `${userId}:${familyId}`
+  const answererNudgedFamilyIds = new Set<string>();
+
+  for (const dq of candidateDQs) {
+    if (dq.date < answererNudgeWindowStart) continue; // 4일 윈도우 밖 제외
+
+    const memberships = membershipsByFamily.get(dq.familyId);
+    if (!memberships || memberships.length < 2) continue; // 1인 가족 스킵
+
+    const answeredSet = answeredByQuestion.get(dq.questionId);
+    if (!answeredSet || answeredSet.size === 0) continue;
+
+    // 해당 질문 기준 미답변(그리고 skip 아님) 멤버 수
+    const pending = memberships.filter(
+      (m) => !(answeredSet.has(m.userId)) && !isSameDate(m.skippedDate, dq.date)
+    );
+    if (pending.length === 0) continue; // 전원 답변/스킵 → 재촉 불필요
+
+    // 이 질문에 답변한 멤버 = 답변자 후보
+    for (const m of memberships) {
+      if (!answeredSet.has(m.userId)) continue;
+      const user = m.user;
+      if (!user) continue;
+      answererQuestionCount.set(
+        m.userId,
+        (answererQuestionCount.get(m.userId) ?? 0) + 1
+      );
+      // pendingCount 는 가장 많았던 질문 기준(대표값) — 단일 질문 시 이 값이 본문 표시됨
+      const prevPending = answererPendingCount.get(m.userId) ?? 0;
+      if (pending.length > prevPending) answererPendingCount.set(m.userId, pending.length);
+      if (!answererUserMap.has(m.userId)) answererUserMap.set(m.userId, user);
+      answererDbKeys.add(`${m.userId}:${dq.familyId}`);
+    }
+    answererNudgedFamilyIds.add(dq.familyId);
+  }
+
+  function makeAnswererBody(
+    locale: string | null,
+    questionCount: number,
+    pendingCount: number
+  ): { title: string; body: string } {
+    const msgs = getPushMessages(locale);
+    return {
+      title: msgs.answererNudge.title,
+      body:
+        questionCount > 1
+          ? msgs.answererNudge.bodyMulti(questionCount)
+          : msgs.answererNudge.body(pendingCount),
+    };
+  }
+
+  // DB 알림
+  const answererDbTasks: Promise<unknown>[] = [];
+  for (const key of answererDbKeys) {
+    const [userId, familyIdForNotif] = key.split(':');
+    const user = answererUserMap.get(userId);
+    if (!user) continue;
+    const questionCount = answererQuestionCount.get(userId) ?? 1;
+    const pendingCount = answererPendingCount.get(userId) ?? 1;
+    const { title, body } = makeAnswererBody(user.locale, questionCount, pendingCount);
+    answererDbTasks.push(
+      notificationService
+        .createNotification(userId, 'ANSWERER_NUDGE', title, body, familyIdForNotif)
+        .catch((e) => {
+          console.warn('[AnswererNudge] 알림 저장 실패:', e);
+        })
+    );
+  }
+  await Promise.all(answererDbTasks);
+
+  // 푸시 — 유저당 1회
+  const answererPushTasks: Promise<unknown>[] = [];
+  for (const [userId, user] of answererUserMap) {
+    if (!user.notifAnswererNudge) continue;
+    const questionCount = answererQuestionCount.get(userId) ?? 1;
+    const pendingCount = answererPendingCount.get(userId) ?? 1;
+    const { title, body } = makeAnswererBody(user.locale, questionCount, pendingCount);
+
+    if (user.apnsToken) {
+      answererPushTasks.push(
+        (async () => {
+          const badgeCount = await notificationService.getUnreadCount(userId);
+          await pushService.sendApnsPush(
+            user.apnsToken!,
+            title,
+            body,
+            'ANSWERER_NUDGE',
+            badgeCount
+          );
+        })().catch((e) => {
+          console.warn('[AnswererNudge] APNs 푸시 실패:', e);
+        })
+      );
+    }
+    if (user.fcmToken) {
+      answererPushTasks.push(
+        pushService
+          .sendFcmPush(user.fcmToken, title, body, 'ANSWERER_NUDGE')
+          .catch((e) => {
+            console.warn('[AnswererNudge] FCM 푸시 실패:', e);
+          })
+      );
+    }
+  }
+  await Promise.all(answererPushTasks);
+
+  console.log(
+    `[AnswererNudge] Nudged ${answererUserMap.size} answerers across ${answererNudgedFamilyIds.size} families`
   );
 }
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -259,6 +259,7 @@ export class UserService {
       notifAnswer: user.notifAnswer,
       notifNudge: user.notifNudge,
       notifQuestion: user.notifQuestion,
+      notifAnswererNudge: user.notifAnswererNudge,
       quietHoursEnabled: user.quietHoursEnabled,
       quietHoursStart: user.quietHoursStart,
       quietHoursEnd: user.quietHoursEnd,
@@ -274,6 +275,7 @@ export class UserService {
       notifAnswer?: boolean;
       notifNudge?: boolean;
       notifQuestion?: boolean;
+      notifAnswererNudge?: boolean;
       quietHoursEnabled?: boolean;
       quietHoursStart?: string;
       quietHoursEnd?: string;
@@ -286,6 +288,7 @@ export class UserService {
       notifAnswer: updated.notifAnswer,
       notifNudge: updated.notifNudge,
       notifQuestion: updated.notifQuestion,
+      notifAnswererNudge: updated.notifAnswererNudge,
       quietHoursEnabled: updated.quietHoursEnabled,
       quietHoursStart: updated.quietHoursStart,
       quietHoursEnd: updated.quietHoursEnd,

--- a/src/utils/i18n/push.ts
+++ b/src/utils/i18n/push.ts
@@ -21,6 +21,7 @@ interface PushMessages {
   memberAnswered: { title: (senderName: string) => string; body: string };
   answerReminder: { title: string; body: string; bodyMulti: (count: number) => string };
   nudge: { title: string; body: (senderName: string) => string };
+  answererNudge: { title: string; body: (pendingCount: number) => string; bodyMulti: (questionCount: number) => string };
 }
 
 const messagesByLocale: Record<Locale, PushMessages> = {
@@ -42,6 +43,11 @@ const messagesByLocale: Record<Locale, PushMessages> = {
       title: '재촉하기 알림',
       body: (name) => `${name}님이 오늘의 질문에 답변해달라고 합니다`,
     },
+    answererNudge: {
+      title: '가족의 답변을 기다리는 중이에요',
+      body: (pending) => `아직 ${pending}명이 답변하지 않았어요. 접속해서 재촉해볼까요?`,
+      bodyMulti: (questions) => `${questions}개의 질문에 아직 답 안 한 가족이 있어요. 재촉해볼까요?`,
+    },
   },
   en: {
     newQuestion: {
@@ -61,6 +67,11 @@ const messagesByLocale: Record<Locale, PushMessages> = {
       title: 'A gentle nudge',
       body: (name) => `${name} is waiting for your answer on today's question`,
     },
+    answererNudge: {
+      title: 'Waiting on your family',
+      body: (pending) => `${pending} family member${pending > 1 ? 's have' : ' has'} not answered yet. Send a nudge?`,
+      bodyMulti: (questions) => `${questions} questions still need family answers. Nudge them now?`,
+    },
   },
   ja: {
     newQuestion: {
@@ -79,6 +90,11 @@ const messagesByLocale: Record<Locale, PushMessages> = {
     nudge: {
       title: 'リマインドが届きました',
       body: (name) => `${name}さんが今日の質問への回答を待っています`,
+    },
+    answererNudge: {
+      title: '家族の回答を待っています',
+      body: (pending) => `まだ${pending}人が回答していません。アプリを開いてリマインドを送りましょう`,
+      bodyMulti: (questions) => `${questions}件の質問に未回答の家族がいます。リマインドを送りましょう`,
     },
   },
 };


### PR DESCRIPTION
## Jira
- [MG-12](https://ycompany.atlassian.net/browse/MG-12)

## Related
- iOS/Android 알림 토글 UI 후속 티켓 필요 (notifAnswererNudge on/off)

## Summary
- reminderScheduler 에 답변자 재촉 로직 통합 (single Lambda, KST 19:00 cron 공유)
- 4일 윈도우 (오늘 + 과거 3일) — 알림 피로 최소화
- 조건: 본인 답변 완료 + 가족 중 1명 이상 미답변
- 유저 단위 푸시 dedup, (유저, 가족) 단위 DB 알림
- Prisma: `User.notifAnswererNudge` + `NotificationType.ANSWERER_NUDGE`
- i18n ko/en/ja, UserService 선호도 API 확장

## ⚠️ 배포 전
마이그레이션 파일은 로컬 `prisma/migrations/20260419130000_add_answerer_nudge/` 에 있으며 gitignore 상태. deploy 전에 `prisma migrate deploy` 실행 필수.

## Test plan
- [x] 유닛 테스트 18/18 통과 (기존 12 + 신규 6)
- [x] 전체 회귀 104/104 통과
- [x] staging 배포 후 수동 Lambda invoke → CloudWatch 로그 확인
- [x] 실기기: 2인 가족 시나리오 (한 명 답변 / 한 명 미답변) 양쪽 각각 적절한 알림 수신
- [x] notifAnswererNudge=false 로 토글 후 푸시 미수신 확인
- [x] prod 배포 및 19:00 KST 자동 cron 동작 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)