### PR TITLE
feat(scheduler): 적응형 질문 발행 — 전원 답변 기반, 자동교체 제거 (MG-16)

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -30,16 +30,14 @@ export async function assignDailyQuestions(): Promise<void> {
     });
     if (existing) continue;
 
-    // 최근 미완료 질문 확인 (48시간 이내만 블로킹, 그 이상은 자동 넘김)
-    const twoDaysAgo = new Date(today);
-    twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
-
-    const recentDQ = await prisma.dailyQuestion.findFirst({
-      where: { familyId: family.id, date: { gte: twoDaysAgo, lt: today } },
+    // MG-16: 자동교체 없음. 가장 최근 DQ가 미완료면 무한정 대기.
+    // 완료된 경우에만 새 질문 발급. 48h 자동 넘김 로직 제거.
+    const latestDQ = await prisma.dailyQuestion.findFirst({
+      where: { familyId: family.id, date: { lt: today } },
       orderBy: { date: 'desc' },
     });
 
-    if (recentDQ) {
+    if (latestDQ) {
       const memberships = await prisma.familyMembership.findMany({
         where: { familyId: family.id },
         select: { userId: true, skippedDate: true },
@@ -48,7 +46,7 @@ export async function assignDailyQuestions(): Promise<void> {
       const answeredUserIds = new Set(
         (await prisma.answer.findMany({
           where: {
-            questionId: recentDQ.questionId,
+            questionId: latestDQ.questionId,
             userId: { in: memberships.map((m) => m.userId) },
           },
           select: { userId: true },
@@ -58,11 +56,13 @@ export async function assignDailyQuestions(): Promise<void> {
       const allCompleted = memberships.every(
         (m) =>
           answeredUserIds.has(m.userId) ||
-          (m.skippedDate !== null && m.skippedDate.getTime() === recentDQ.date.getTime())
+          (m.skippedDate !== null && m.skippedDate.getTime() === latestDQ.date.getTime())
       );
 
       if (!allCompleted) {
-        console.log(`[Scheduler] Skipped family ${family.id}: recent question not completed (within 48h window)`);
+        console.log(
+          `[Scheduler] Skipped family ${family.id}: previous question (${latestDQ.date.toISOString().split('T')[0]}) not completed`
+        );
         continue;
       }
     }

--- a/src/services/FamilyService.ts
+++ b/src/services/FamilyService.ts
@@ -9,6 +9,13 @@ import {
 } from '../models';
 import { Errors } from '../middleware/errorHandler';
 import { generateInviteCode, isValidInviteCode } from '../utils/inviteCode';
+import { QuestionService } from './QuestionService';
+
+function getKstToday(): Date {
+  const now = new Date();
+  const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' });
+  return new Date(kstDateStr + 'T00:00:00.000Z');
+}
 
 const MAX_GROUPS = 3;
 const MAX_MEMBERS = 8; // MongleScene 수용 한계 기반 (collisionRadius=76pt, 유효 씬 면적 기준)
@@ -66,6 +73,15 @@ export class FamilyService {
 
       return newFamily;
     });
+
+    // MG-16: 가입 즉시 첫 질문 발급 (스케줄러의 KST 11시 cron까지 기다리지 않음).
+    // 트랜잭션 외부에서 호출 — 질문 풀 조회 등 부수효과가 있고, 실패해도 가족 생성은 성공해야 함.
+    try {
+      const questionService = new QuestionService();
+      await questionService.assignQuestionToFamily(family.id, getKstToday());
+    } catch (e) {
+      console.warn('[FamilyService] 첫 질문 발급 실패 (다음 스케줄러 실행 시 자동 재시도):', e);
+    }
 
     return this.getFamilyWithMembers(family.id);
   }

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -53,25 +53,21 @@ export class QuestionService {
     });
 
     if (!dailyQuestion) {
-      // 가장 최근 미완료 질문을 탐색 (어제 → 그 이전)
-      // 48시간(2일) 이상 지난 질문은 미완료여도 자동 넘김
-      const twoDaysAgo = new Date(today);
-      twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
-
-      const recentDQ = await prisma.dailyQuestion.findFirst({
-        where: { familyId, date: { gte: twoDaysAgo, lt: today } },
+      // MG-16: 자동교체 없음. 가장 최근 DQ를 무기한 carry over.
+      // - 미완료면 그대로 (전원 답변 대기 중)
+      // - 완료됐는데 오늘자가 없으면 (스케줄러 발급 전) 그대로 (다음 11시까지 대기)
+      // - DQ가 아예 없으면 (신규 가족 등) 즉시 배정
+      const latestDQ = await prisma.dailyQuestion.findFirst({
+        where: { familyId, date: { lt: today } },
         include: { question: true },
         orderBy: { date: 'desc' },
       });
 
-      if (recentDQ) {
-        const allCompleted = await this.isQuestionCompleted(familyId, recentDQ.questionId, recentDQ.date);
-        if (!allCompleted) {
-          // 미완료 질문이 48시간 이내: 해당 질문을 그대로 반환
-          return this.toDailyQuestionResponse(recentDQ, user.id, familyId, lang);
-        }
+      if (latestDQ) {
+        return this.toDailyQuestionResponse(latestDQ, user.id, familyId, lang);
       }
-      // 미완료 질문 없거나 48시간 초과 → 새 질문 배정
+
+      // 첫 질문이 한 번도 없는 경우(가입 직후 등) → 즉시 배정
       dailyQuestion = await this.assignQuestionToFamily(familyId, today);
     }
 
@@ -134,17 +130,13 @@ export class QuestionService {
     });
 
     if (!dailyQuestion) {
-      const twoDaysAgo = new Date(today);
-      twoDaysAgo.setUTCDate(twoDaysAgo.getUTCDate() - 2);
-      const recentDQ = await prisma.dailyQuestion.findFirst({
-        where: { familyId, date: { gte: twoDaysAgo, lt: today } },
+      // MG-16: 자동교체 없음. 가장 최근 DQ를 무기한 carry over.
+      const latestDQ = await prisma.dailyQuestion.findFirst({
+        where: { familyId, date: { lt: today } },
         include: { question: true },
         orderBy: { date: 'desc' },
       });
-      if (recentDQ) {
-        const allCompleted = await this.isQuestionCompleted(familyId, recentDQ.questionId, recentDQ.date);
-        if (!allCompleted) dailyQuestion = recentDQ;
-      }
+      if (latestDQ) dailyQuestion = latestDQ;
     }
 
     if (!dailyQuestion) throw Errors.notFound('오늘의 질문');
@@ -442,9 +434,10 @@ export class QuestionService {
   }
 
   /**
-   * 가족에게 질문 배정 (최근 30일 제외)
+   * 가족에게 질문 배정 (최근 30일 제외).
+   * MG-16: 가족 생성 직후 첫 질문 발급에도 사용되므로 public.
    */
-  private async assignQuestionToFamily(familyId: string, date: Date) {
+  async assignQuestionToFamily(familyId: string, date: Date) {
     const recentDate = new Date(date);
     recentDate.setDate(recentDate.getDate() - 30);
 

--- a/src/services/dailyQuestionCompletion.ts
+++ b/src/services/dailyQuestionCompletion.ts
@@ -1,37 +1,20 @@
 import prisma from '../utils/prisma';
 
-/**
- * KST 기준 오늘을 UTC 자정 Date 로 반환.
- * (@db.Date 칼럼의 저장 컨벤션과 동일)
- */
-function getKstToday(): Date {
-  const now = new Date();
-  const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' });
-  return new Date(kstDateStr + 'T00:00:00.000Z');
-}
-
 function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boolean {
   if (!a || !b) return false;
   return a.toISOString().split('T')[0] === b.toISOString().split('T')[0];
 }
 
 /**
- * 해당 DailyQuestion이 "그룹 전원이 답변 또는 패스 완료" 상태가 되었는지 확인한 뒤,
- * 완료 상태라면 DailyQuestion.date 를 KST 기준 오늘로 이동(=finalize)시킨다.
+ * 해당 DailyQuestion이 "그룹 전원이 답변 또는 패스 완료" 상태인지 확인하고 로깅한다.
  *
- * 배정일자(4/7)에 받아온 질문을 실제로는 4/9에 그룹이 다 같이 마무리하는 경우,
- * history/정렬/스케줄러 모두 "4/9에 완료됐다" 로 동작하도록 만드는 핵심 함수.
+ * MG-16 이전: 완료 시 DQ.date 를 오늘로 이동시켜 history/스케줄러 정렬에 활용했음.
+ * MG-16 이후: "전원 답변 → 다음 11시 새 질문 발행" 룰을 위해 같은 날 두 개의 DQ가
+ * 필요해졌고, @@unique([familyId, date]) 충돌을 피하려면 date 가 배정일로 고정돼야 함.
+ * 따라서 date 이동은 더 이상 수행하지 않는다. 완료 여부 판정은 호출 측에서 런타임으로
+ * (isQuestionCompleted/스케줄러) 수행한다.
  *
- * 동작:
- *   1. DQ 가 이미 오늘 날짜이면 no-op (이미 finalize 됨)
- *   2. 그룹 멤버 전원의 답변/패스 상태 확인
- *   3. 완료 상태라면 트랜잭션으로:
- *       - DailyQuestion.date ← 오늘 (KST)
- *       - 기존 DQ.date 기준으로 패스했던 멤버들의 FamilyMembership.skippedDate 도 함께 오늘로 이동
- *         (= 완료 스냅샷과 일관성 유지 — isSameDate(skippedDate, dq.date) 가 계속 true 여야 함)
- *   4. @@unique([familyId, date]) 충돌 (동일 familyId 에 오늘자 DQ 가 이미 존재) 시 원본 유지
- *
- * 멱등성: 여러 번 호출돼도 안전 (이미 완료됐거나 이미 이동된 경우 no-op).
+ * 멱등성: 여러 번 호출돼도 안전 (DB 변경 없음).
  */
 export async function tryFinalizeDailyQuestion(params: {
   familyId: string;
@@ -65,34 +48,7 @@ export async function tryFinalizeDailyQuestion(params: {
   );
   if (!allCompleted) return;
 
-  const today = getKstToday();
-  // 이미 오늘자로 finalize 된 경우 (= 당일 안에 모두 답함)
-  if (isSameDate(dq.date, today)) return;
-
-  try {
-    await prisma.$transaction([
-      prisma.dailyQuestion.update({
-        where: { id: dq.id },
-        data: { date: today },
-      }),
-      // 기존 DQ.date 기준으로 패스했던 멤버들의 skippedDate 도 동일하게 이동
-      prisma.familyMembership.updateMany({
-        where: { familyId, skippedDate: dq.date },
-        data: { skippedDate: today },
-      }),
-    ]);
-    console.log(
-      `[DQ Finalize] family=${familyId} dq=${dq.id} ${dq.date.toISOString().split('T')[0]} → ${today.toISOString().split('T')[0]}`
-    );
-  } catch (e) {
-    const code = (e as { code?: string } | null)?.code;
-    if (code === 'P2002') {
-      // 동일 familyId + 오늘 날짜에 이미 다른 DQ 가 존재 (희귀 동시성 케이스)
-      console.warn(
-        `[DQ Finalize] unique 충돌, 날짜 이동 생략: family=${familyId} dq=${dailyQuestionId} → ${today.toISOString().split('T')[0]}`
-      );
-      return;
-    }
-    throw e;
-  }
+  console.log(
+    `[DQ Finalize] family=${familyId} dq=${dq.id} date=${dq.date.toISOString().split('T')[0]} 전원 완료`
+  );
 }


### PR DESCRIPTION
## Jira
- [MG-16](https://ycompany.atlassian.net/browse/MG-16)

## Summary
- KST 11시 cron 유지하되 발행 기준을 "오늘 미배정"에서 **"가장 최근 DQ 완료"**로 변경
- 48시간 자동 넘김 제거 — 그룹이 답변 안 하면 무한정 대기 (사용자 요청 "자동교체 없음")
- \`tryFinalizeDailyQuestion\`의 date 이동 제거 — 같은 날 두 개의 DQ가 가능해야 "오전 답변→당일 11시 새 질문" 룰 성립 (\`@@unique([familyId, date])\` 충돌 회피)
- \`createFamily\` 후 즉시 첫 질문 발급 — 신규 가족이 다음 11시까지 빈 화면 보지 않도록
- 19시 미답변/답변자 nudge 알림은 기존 로직 그대로 검증 통과 (18 reminder 테스트 PASS)

## 주요 파일
- \`src/scheduler.ts\` — assignDailyQuestions 핵심 분기 단순화
- \`src/services/dailyQuestionCompletion.ts\` — finalize 시 DB 변경 없는 no-op으로 축소
- \`src/services/QuestionService.ts\` — getTodayQuestion/skipTodayQuestion 무기한 carry-over, assignQuestionToFamily public
- \`src/services/FamilyService.ts\` — createFamily 트랜잭션 후 첫 질문 발급 try/catch

## Test plan
- [x] \`npm test\` 104/104 PASS (변경 없이 모든 기존 테스트 통과)
- [ ] dev 스테이징 배포 후 시나리오:
  - [ ] 9시 답변 완료 → 11시 새 Q + 푸시
  - [ ] 13시 답변 완료 → 다음날 11시 새 Q
  - [ ] 가족 신규 생성 → 즉시 Q 노출
  - [ ] 미완료 72h → Q 유지
  - [ ] 19시 ANSWER_REQUEST 푸시 + DB 알림 도착 확인
  - [ ] 19시 ANSWERER_NUDGE 푸시 도착 확인 (1명 답변/1명 미답변 케이스)

## 호환성
- 이미 finalize되어 date가 이동된 기존 DQ는 그대로 유지 (history 표시 일관)
- 신규 DQ만 배정일 기준으로 저장됨

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)