### PR TITLE
fix(reminder): 답변자/미답변자 메시지 분기 + 전원 발송 (MG-19)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -206,4 +206,5 @@ enum NotificationType {
   ANSWER_REQUEST
   ANSWERER_NUDGE
   BADGE_EARNED
+  REMINDER
 }

--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -38,7 +38,6 @@ const mockUser = {
   fcmToken: null,
   locale: 'ko',
   notifQuestion: true,
-  notifAnswererNudge: true,
 };
 
 describe('getKstMidnightUtc', () => {
@@ -61,7 +60,21 @@ describe('getKstMidnightUtc', () => {
   });
 });
 
-describe('sendDailyReminders', () => {
+/**
+ * MG-19: 저녁 7시 리마인더 알림 — 답변자/미답변자 메시지 분기 + 전원 발송
+ *
+ * 신규 스펙:
+ *   - 그룹 내 미답변자 ≥ 1 일 때 그룹 전원(답변자+미답변자)에게 발송
+ *   - type=REMINDER (DB 레코드 및 FCM/APNs payload)
+ *   - 답변자:   "미답변자가 있어요" / "그룹에 접속해서 재촉하기를 해봐요"
+ *   - 미답변자: "오늘 질문에 답변하지 않았어요" / "그룹에 접속해서 답변을 달아봐요"
+ *   - notifQuestion 토글 존중
+ */
+describe('sendDailyReminders (MG-19)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('후보 DailyQuestion이 없으면 배치 조회와 알림 호출을 건너뛴다', async () => {
     mockDQFindMany.mockResolvedValue([]);
 
@@ -73,7 +86,7 @@ describe('sendDailyReminders', () => {
     expect(mockSendApnsPush).not.toHaveBeenCalled();
   });
 
-  it('미답변 멤버에게 DB 알림과 APNs 푸시를 각 1회 발송한다', async () => {
+  it('1인 가족 미답변자에게 REMINDER(미답변자 문구)로 DB/푸시 1회 발송한다', async () => {
     mockDQFindMany.mockResolvedValue([
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
@@ -87,16 +100,23 @@ describe('sendDailyReminders', () => {
     expect(mockCreateNotification).toHaveBeenCalledTimes(1);
     expect(mockCreateNotification).toHaveBeenCalledWith(
       'user-1',
-      'ANSWER_REQUEST',
-      expect.any(String),
-      expect.any(String),
+      'REMINDER',
+      '오늘 질문에 답변하지 않았어요',
+      '그룹에 접속해서 답변을 달아봐요',
       'fam-1'
     );
     expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+    expect(mockSendApnsPush).toHaveBeenCalledWith(
+      'apns-token',
+      '오늘 질문에 답변하지 않았어요',
+      '그룹에 접속해서 답변을 달아봐요',
+      'REMINDER',
+      0
+    );
     expect(mockSendFcmPush).not.toHaveBeenCalled();
   });
 
-  it('전원 답변 완료 시 알림을 발송하지 않는다', async () => {
+  it('전원 답변 완료 시 알림을 발송하지 않는다 (미답변자 0명)', async () => {
     mockDQFindMany.mockResolvedValue([
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
@@ -126,7 +146,50 @@ describe('sendDailyReminders', () => {
     expect(mockCreateNotification).not.toHaveBeenCalled();
   });
 
-  it('동일 유저의 미답변 복수 건이어도 (유저, 가족) 단위 1건으로 통합되며, 문구는 카운트 없이 단순화된다', async () => {
+  it('부분 답변 시 답변자/미답변자 각자 분기된 문구로 REMINDER 발송한다', async () => {
+    const otherUser = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+    ]);
+    // user-1 답변, user-2 미답변
+    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
+
+    await sendDailyReminders();
+
+    // DB 알림: user-1(답변자 문구), user-2(미답변자 문구) 각 1건 — 모두 type=REMINDER
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-1',
+      'REMINDER',
+      '미답변자가 있어요',
+      '그룹에 접속해서 재촉하기를 해봐요',
+      'fam-1'
+    );
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-2',
+      'REMINDER',
+      '오늘 질문에 답변하지 않았어요',
+      '그룹에 접속해서 답변을 달아봐요',
+      'fam-1'
+    );
+
+    // APNs 푸시: 각 유저에게 1회씩 (총 2회), type=REMINDER
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(2);
+    const user1Push = mockSendApnsPush.mock.calls.find((c) => c[0] === 'apns-token');
+    const user2Push = mockSendApnsPush.mock.calls.find((c) => c[0] === 'apns-2');
+    expect(user1Push).toBeDefined();
+    expect(user1Push![1]).toBe('미답변자가 있어요');
+    expect(user1Push![3]).toBe('REMINDER');
+    expect(user2Push).toBeDefined();
+    expect(user2Push![1]).toBe('오늘 질문에 답변하지 않았어요');
+    expect(user2Push![3]).toBe('REMINDER');
+  });
+
+  it('동일 유저의 미답변 복수 건이어도 (유저, 가족) 단위 1건으로 통합된다', async () => {
     mockDQFindMany.mockResolvedValue([
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
       { id: 'dq-2', questionId: 'q-2', familyId: 'fam-1', date: new Date('2026-04-16') },
@@ -139,13 +202,8 @@ describe('sendDailyReminders', () => {
 
     await sendDailyReminders();
 
-    // (유저, 가족) 단위 1건
+    // (유저, 가족) 단위 1건 — 여러 질문 미답변이어도 dedup
     expect(mockCreateNotification).toHaveBeenCalledTimes(1);
-    const title = mockCreateNotification.mock.calls[0][2] as string;
-    const body = mockCreateNotification.mock.calls[0][3] as string;
-    expect(title).toBe('오늘의 질문, 아직 답변 전이에요');
-    expect(body).not.toMatch(/\d+건/); // "N건" 형식 문구 제거 확인
-    // 푸시도 1회
     expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
   });
 
@@ -186,7 +244,7 @@ describe('sendDailyReminders', () => {
     expect(mockSendApnsPush).not.toHaveBeenCalled();
   });
 
-  it('FCM 토큰만 있는 유저에게는 FCM 푸시만 발송된다', async () => {
+  it('FCM 토큰만 있는 유저에게는 FCM 푸시만 발송된다 (type=REMINDER)', async () => {
     mockDQFindMany.mockResolvedValue([
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
@@ -204,71 +262,15 @@ describe('sendDailyReminders', () => {
 
     expect(mockSendApnsPush).not.toHaveBeenCalled();
     expect(mockSendFcmPush).toHaveBeenCalledTimes(1);
-  });
-
-  it('가족 멤버 중 일부만 답변했으면 미답변 멤버만 대상이 된다', async () => {
-    const otherUser = { ...mockUser, id: 'user-2' };
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
-
-    await sendDailyReminders();
-
-    // user-2(미답변)에게 ANSWER_REQUEST 1건 + user-1(답변자)에게 ANSWERER_NUDGE 1건 = 총 2건
-    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
-    expect(mockCreateNotification).toHaveBeenCalledWith(
-      'user-2',
-      'ANSWER_REQUEST',
-      expect.any(String),
-      expect.any(String),
-      'fam-1'
-    );
-    expect(mockCreateNotification).toHaveBeenCalledWith(
-      'user-1',
-      'ANSWERER_NUDGE',
-      expect.any(String),
-      expect.any(String),
-      'fam-1'
+    expect(mockSendFcmPush).toHaveBeenCalledWith(
+      'fcm-token',
+      '오늘 질문에 답변하지 않았어요',
+      '그룹에 접속해서 답변을 달아봐요',
+      'REMINDER'
     );
   });
-});
 
-describe('sendDailyReminders - answerer nudge (MG-12)', () => {
-  it('본인 답변 + 가족 1명 미답변 → 답변자에게 ANSWERER_NUDGE DB/푸시 1회', async () => {
-    const otherUser = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
-
-    await sendDailyReminders();
-
-    const nudgeCalls = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeCalls).toHaveLength(1);
-    expect(nudgeCalls[0][0]).toBe('user-1');
-    // body 에 "1명" 포함 (pendingCount=1)
-    expect(nudgeCalls[0][3]).toContain('1명');
-
-    // APNs 푸시: user-1(답변자) + user-2(미답변) 각 1회 = 2회
-    expect(mockSendApnsPush).toHaveBeenCalledTimes(2);
-    const apnsCallsAnswerer = mockSendApnsPush.mock.calls.filter(
-      (c) => c[3] === 'ANSWERER_NUDGE'
-    );
-    expect(apnsCallsAnswerer).toHaveLength(1);
-  });
-
-  it('전원 답변 완료 → 답변자 재촉 발송 안 함', async () => {
+  it('답변자가 있더라도 그룹 전원이 답변이면 발송하지 않는다', async () => {
     const otherUser = { ...mockUser, id: 'user-2' };
     mockDQFindMany.mockResolvedValue([
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
@@ -284,102 +286,7 @@ describe('sendDailyReminders - answerer nudge (MG-12)', () => {
 
     await sendDailyReminders();
 
-    const nudgeCalls = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeCalls).toHaveLength(0);
-  });
-
-  it('1인 가족 → 답변자 재촉 발송 안 함 (멤버십 1명 스킵)', async () => {
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
-
-    await sendDailyReminders();
-
-    const nudgeCalls = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeCalls).toHaveLength(0);
-  });
-
-  it('notifAnswererNudge=false 유저는 푸시 제외 (DB 알림은 저장)', async () => {
-    const optedOutUser = { ...mockUser, notifAnswererNudge: false };
-    const otherUser = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: optedOutUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
-
-    await sendDailyReminders();
-
-    const nudgeDb = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeDb).toHaveLength(1); // DB 알림은 저장
-
-    const nudgeApns = mockSendApnsPush.mock.calls.filter(
-      (c) => c[3] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeApns).toHaveLength(0); // 푸시는 제외
-  });
-
-  it('4일 윈도우 밖 DQ(5일 전)는 답변자 재촉 대상에서 제외', async () => {
-    const otherUser = { ...mockUser, id: 'user-2' };
-    // 오늘 = now — mock 기준일 없음. REMINDER_WINDOW_DAYS=7 이므로 DQ 5일 전이 7일 윈도우엔 들어옴
-    // 그러나 ANSWERER_NUDGE_WINDOW_DAYS=4 이므로 답변자 재촉 대상에선 빠져야 함
-    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-old', questionId: 'q-old', familyId: 'fam-1', date: fiveDaysAgo },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-old', userId: 'user-1' }]);
-
-    await sendDailyReminders();
-
-    const nudgeCalls = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeCalls).toHaveLength(0);
-  });
-
-  it('답변자가 복수 질문에서 가족 미답변 상태면 bodyMulti 문구 사용', async () => {
-    const otherUser = { ...mockUser, id: 'user-2' };
-    const today = new Date();
-    const y1 = new Date(today.getTime() - 1 * 24 * 60 * 60 * 1000);
-    const y2 = new Date(today.getTime() - 2 * 24 * 60 * 60 * 1000);
-    mockDQFindMany.mockResolvedValue([
-      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: today },
-      { id: 'dq-2', questionId: 'q-2', familyId: 'fam-1', date: y1 },
-      { id: 'dq-3', questionId: 'q-3', familyId: 'fam-1', date: y2 },
-    ]);
-    mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
-    ]);
-    mockAnswerFindMany.mockResolvedValue([
-      { questionId: 'q-1', userId: 'user-1' },
-      { questionId: 'q-2', userId: 'user-1' },
-      { questionId: 'q-3', userId: 'user-1' },
-    ]);
-
-    await sendDailyReminders();
-
-    const nudgeCalls = mockCreateNotification.mock.calls.filter(
-      (c) => c[1] === 'ANSWERER_NUDGE'
-    );
-    expect(nudgeCalls).toHaveLength(1); // (user-1, fam-1) 단위 1건
-    expect(nudgeCalls[0][3]).toContain('3개'); // 3개 질문
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
   });
 });

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -8,7 +8,6 @@ const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
 
 export const REMINDER_WINDOW_DAYS = 7;
-export const ANSWERER_NUDGE_WINDOW_DAYS = 4;
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -32,16 +31,22 @@ function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boo
 }
 
 /**
- * 자동 재촉 알림 발송 (KST 19:00 스케줄).
+ * MG-19: 저녁 7시 리마인더 알림 (KST 19:00 스케줄, type=REMINDER).
  *
  * 조건:
  *   - 최근 REMINDER_WINDOW_DAYS 이내 배정된 모든 DailyQuestion
- *   - 아직 답변/패스하지 않은 멤버에게만
- *   - 유저당 1회 푸시 (다중 그룹 소속, 다건 미답변이어도 중복 발송 없음)
- *   - DB 알림은 (유저, 가족) 단위 1건으로 제한하여 과도한 알림 방지
- *   - 미답변이 다건이어도 표시 문구는 단순화("오늘의 질문, 아직 답변 전이에요")
+ *   - 가족 내 미답변 멤버가 1명 이상일 때에만 해당 가족을 리마인드 대상으로 포함
+ *   - 발송 대상은 **그룹 전원** (답변자 + 미답변자) — 클라이언트에서 type=REMINDER 로 라우팅
+ *   - 메시지 분기 (사용자별 해당 가족의 오늘 답변 여부 기준):
+ *       · 답변자:   title "미답변자가 있어요" / body "그룹에 접속해서 재촉하기를 해봐요"
+ *       · 미답변자: title "오늘 질문에 답변하지 않았어요" / body "그룹에 접속해서 답변을 달아봐요"
+ *   - 유저당 푸시 1회 (다중 가족 소속 시 중복 발송 방지). 분기는 "해당 유저가 어느 가족이라도
+ *     미답변이면 미답변자 문구" 우선 — 본인 미답변 케이스가 더 긴급하기 때문.
+ *   - DB 알림은 (유저, 가족) 단위 1건 — 클라이언트 알림 리스트에서 가족별 행으로 표시.
+ *   - 푸시 대상은 사용자별 `notifQuestion` 토글 존중.
  *
- * 전원이 이미 완료된 경우는 건너뜀.
+ * MG-12 의 ANSWERER_NUDGE 경로는 본 REMINDER 경로로 통합됨 (답변자 전용 메시지 분기로 승계).
+ * 수동 재촉(NudgeService → type ANSWER_REQUEST) 및 답변완료(MEMBER_ANSWERED) 경로는 변경 없음.
  */
 export async function sendDailyReminders(): Promise<void> {
   const kstMidnight = getKstMidnightUtc();
@@ -56,11 +61,6 @@ export async function sendDailyReminders(): Promise<void> {
     console.log('[Reminder] No candidate questions in window');
     return;
   }
-
-  // 답변자 재촉(answerer nudge) 윈도우는 미답변 재촉보다 짧음 (기본 4일 = 오늘+과거 3일)
-  const answererNudgeWindowStart = new Date(
-    kstMidnight.getTime() - ANSWERER_NUDGE_WINDOW_DAYS * DAY_MS
-  );
 
   // 배치 조회 ①: 해당 가족들의 멤버십 일괄 조회 (N+1 제거)
   const familyIds = Array.from(new Set(candidateDQs.map((dq) => dq.familyId)));
@@ -77,7 +77,6 @@ export async function sendDailyReminders(): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
-          notifAnswererNudge: true,
         },
       },
     },
@@ -112,10 +111,14 @@ export async function sendDailyReminders(): Promise<void> {
     else answeredByQuestion.set(a.questionId, new Set([a.userId]));
   }
 
-  // 집계: (유저, 가족) 키, 푸시 대상 유저 정보
-  //   - 미답변 카운트는 더 이상 푸시 문구에 쓰지 않지만, 추후 확장(분석 등) 위해 제거는 하지 않음
+  // 집계:
+  //   - userInfoMap:        푸시 대상 유저 정보 (푸시는 유저당 1회)
+  //   - dbNotifByKey:       (유저, 가족) → 해당 가족에서 본인이 미답변 1건이라도 있었는지 (분기용)
+  //   - userHasUnanswered:  유저 전역으로 어떤 가족이든 본인이 미답변이었는지 (푸시 문구 분기용)
+  //   - remindedFamilyIds:  실제로 리마인드 발송 대상이 된 가족 수 (로깅)
   const userInfoMap = new Map<string, MembershipUser>();
-  const dbNotifKeys = new Set<string>(); // `${userId}:${familyId}`
+  const dbNotifByKey = new Map<string, { userId: string; familyId: string; userUnanswered: boolean }>();
+  const userHasUnanswered = new Map<string, boolean>();
   const remindedFamilyIds = new Set<string>();
 
   for (const dq of candidateDQs) {
@@ -123,38 +126,56 @@ export async function sendDailyReminders(): Promise<void> {
     if (!memberships || memberships.length === 0) continue;
 
     const answeredSet = answeredByQuestion.get(dq.questionId);
+
+    // 이 질문의 미답변자(skip 제외) — 1명 이상이어야 리마인드 발송
     const unfinished = memberships.filter(
       (m) => !(answeredSet?.has(m.userId) ?? false) && !isSameDate(m.skippedDate, dq.date)
     );
     if (unfinished.length === 0) continue;
 
-    for (const m of unfinished) {
+    // 그룹 전원(답변자+미답변자) 을 발송 대상으로 등록
+    for (const m of memberships) {
       const user = m.user;
       if (!user) continue;
+      // skip 멤버는 본인 의사로 오늘 건너뛰기 했으므로 리마인드 대상에서 제외
+      if (isSameDate(m.skippedDate, dq.date)) continue;
+
       if (!userInfoMap.has(m.userId)) userInfoMap.set(m.userId, user);
-      dbNotifKeys.add(`${m.userId}:${dq.familyId}`);
+
+      const selfUnanswered = !(answeredSet?.has(m.userId) ?? false);
+      if (selfUnanswered) userHasUnanswered.set(m.userId, true);
+      else if (!userHasUnanswered.has(m.userId)) userHasUnanswered.set(m.userId, false);
+
+      const key = `${m.userId}:${dq.familyId}`;
+      const existing = dbNotifByKey.get(key);
+      if (!existing) {
+        dbNotifByKey.set(key, {
+          userId: m.userId,
+          familyId: dq.familyId,
+          userUnanswered: selfUnanswered,
+        });
+      } else if (selfUnanswered) {
+        existing.userUnanswered = true; // 미답변 우선
+      }
     }
     remindedFamilyIds.add(dq.familyId);
   }
 
-  function makeBody(locale: string | null): { title: string; body: string } {
+  function makeBody(locale: string | null, unanswered: boolean): { title: string; body: string } {
     const msgs = getPushMessages(locale);
-    return {
-      title: msgs.answerReminder.title,
-      body: msgs.answerReminder.body,
-    };
+    const set = unanswered ? msgs.reminder.unanswered : msgs.reminder.answered;
+    return { title: set.title, body: set.body };
   }
 
-  // DB 알림 — (유저, 가족) 단위 1건
+  // DB 알림 — (유저, 가족) 단위 1건. 본인이 해당 가족에서 미답변이면 미답변자 문구, 아니면 답변자 문구.
   const dbNotifTasks: Promise<unknown>[] = [];
-  for (const key of dbNotifKeys) {
-    const [userId, familyIdForNotif] = key.split(':');
-    const user = userInfoMap.get(userId);
+  for (const entry of dbNotifByKey.values()) {
+    const user = userInfoMap.get(entry.userId);
     if (!user) continue;
-    const { title, body } = makeBody(user.locale);
+    const { title, body } = makeBody(user.locale, entry.userUnanswered);
     dbNotifTasks.push(
       notificationService
-        .createNotification(userId, 'ANSWER_REQUEST', title, body, familyIdForNotif)
+        .createNotification(entry.userId, 'REMINDER', title, body, entry.familyId)
         .catch((e) => {
           console.warn('[Reminder] 알림 저장 실패:', e);
         })
@@ -162,11 +183,12 @@ export async function sendDailyReminders(): Promise<void> {
   }
   await Promise.all(dbNotifTasks);
 
-  // 푸시 — 유저당 1회
+  // 푸시 — 유저당 1회. 유저가 어느 가족에서든 미답변이면 미답변자 문구 사용(본인 답변이 더 긴급).
   const pushTasks: Promise<unknown>[] = [];
   for (const [userId, user] of userInfoMap) {
     if (!user.notifQuestion) continue;
-    const { title, body } = makeBody(user.locale);
+    const unanswered = userHasUnanswered.get(userId) ?? false;
+    const { title, body } = makeBody(user.locale, unanswered);
 
     if (user.apnsToken) {
       pushTasks.push(
@@ -176,7 +198,7 @@ export async function sendDailyReminders(): Promise<void> {
             user.apnsToken!,
             title,
             body,
-            'ANSWER_REQUEST',
+            'REMINDER',
             badgeCount
           );
         })().catch((e) => {
@@ -187,7 +209,7 @@ export async function sendDailyReminders(): Promise<void> {
     if (user.fcmToken) {
       pushTasks.push(
         pushService
-          .sendFcmPush(user.fcmToken, title, body, 'ANSWER_REQUEST')
+          .sendFcmPush(user.fcmToken, title, body, 'REMINDER')
           .catch((e) => {
             console.warn('[Reminder] FCM 푸시 실패:', e);
           })
@@ -198,127 +220,6 @@ export async function sendDailyReminders(): Promise<void> {
 
   console.log(
     `[Reminder] Reminded ${userInfoMap.size} unique users across ${remindedFamilyIds.size} families`
-  );
-
-  // ────────────────────────────────────────────────────────────
-  // MG-12: 답변자 재촉(answerer nudge)
-  //   - 본인은 답변 완료 + 같은 가족 중 최소 1명 미답변
-  //   - 4일 윈도우(오늘+과거 3일). 미답변 재촉(7일)보다 짧게 → 알림 피로 감소
-  //   - 푸시는 유저당 1회, DB 알림은 (유저, 가족) 단위
-  // ────────────────────────────────────────────────────────────
-
-  // 답변자별 집계: 몇 개 질문에서 가족 미답변 상태로 남았는지(questionCount), 총 몇 명 대기 중(pendingMembers)
-  const answererQuestionCount = new Map<string, number>();
-  const answererPendingCount = new Map<string, number>();
-  const answererUserMap = new Map<string, MembershipUser>();
-  const answererDbKeys = new Set<string>(); // `${userId}:${familyId}`
-  const answererNudgedFamilyIds = new Set<string>();
-
-  for (const dq of candidateDQs) {
-    if (dq.date < answererNudgeWindowStart) continue; // 4일 윈도우 밖 제외
-
-    const memberships = membershipsByFamily.get(dq.familyId);
-    if (!memberships || memberships.length < 2) continue; // 1인 가족 스킵
-
-    const answeredSet = answeredByQuestion.get(dq.questionId);
-    if (!answeredSet || answeredSet.size === 0) continue;
-
-    // 해당 질문 기준 미답변(그리고 skip 아님) 멤버 수
-    const pending = memberships.filter(
-      (m) => !(answeredSet.has(m.userId)) && !isSameDate(m.skippedDate, dq.date)
-    );
-    if (pending.length === 0) continue; // 전원 답변/스킵 → 재촉 불필요
-
-    // 이 질문에 답변한 멤버 = 답변자 후보
-    for (const m of memberships) {
-      if (!answeredSet.has(m.userId)) continue;
-      const user = m.user;
-      if (!user) continue;
-      answererQuestionCount.set(
-        m.userId,
-        (answererQuestionCount.get(m.userId) ?? 0) + 1
-      );
-      // pendingCount 는 가장 많았던 질문 기준(대표값) — 단일 질문 시 이 값이 본문 표시됨
-      const prevPending = answererPendingCount.get(m.userId) ?? 0;
-      if (pending.length > prevPending) answererPendingCount.set(m.userId, pending.length);
-      if (!answererUserMap.has(m.userId)) answererUserMap.set(m.userId, user);
-      answererDbKeys.add(`${m.userId}:${dq.familyId}`);
-    }
-    answererNudgedFamilyIds.add(dq.familyId);
-  }
-
-  function makeAnswererBody(
-    locale: string | null,
-    questionCount: number,
-    pendingCount: number
-  ): { title: string; body: string } {
-    const msgs = getPushMessages(locale);
-    return {
-      title: msgs.answererNudge.title,
-      body:
-        questionCount > 1
-          ? msgs.answererNudge.bodyMulti(questionCount)
-          : msgs.answererNudge.body(pendingCount),
-    };
-  }
-
-  // DB 알림
-  const answererDbTasks: Promise<unknown>[] = [];
-  for (const key of answererDbKeys) {
-    const [userId, familyIdForNotif] = key.split(':');
-    const user = answererUserMap.get(userId);
-    if (!user) continue;
-    const questionCount = answererQuestionCount.get(userId) ?? 1;
-    const pendingCount = answererPendingCount.get(userId) ?? 1;
-    const { title, body } = makeAnswererBody(user.locale, questionCount, pendingCount);
-    answererDbTasks.push(
-      notificationService
-        .createNotification(userId, 'ANSWERER_NUDGE', title, body, familyIdForNotif)
-        .catch((e) => {
-          console.warn('[AnswererNudge] 알림 저장 실패:', e);
-        })
-    );
-  }
-  await Promise.all(answererDbTasks);
-
-  // 푸시 — 유저당 1회
-  const answererPushTasks: Promise<unknown>[] = [];
-  for (const [userId, user] of answererUserMap) {
-    if (!user.notifAnswererNudge) continue;
-    const questionCount = answererQuestionCount.get(userId) ?? 1;
-    const pendingCount = answererPendingCount.get(userId) ?? 1;
-    const { title, body } = makeAnswererBody(user.locale, questionCount, pendingCount);
-
-    if (user.apnsToken) {
-      answererPushTasks.push(
-        (async () => {
-          const badgeCount = await notificationService.getUnreadCount(userId);
-          await pushService.sendApnsPush(
-            user.apnsToken!,
-            title,
-            body,
-            'ANSWERER_NUDGE',
-            badgeCount
-          );
-        })().catch((e) => {
-          console.warn('[AnswererNudge] APNs 푸시 실패:', e);
-        })
-      );
-    }
-    if (user.fcmToken) {
-      answererPushTasks.push(
-        pushService
-          .sendFcmPush(user.fcmToken, title, body, 'ANSWERER_NUDGE')
-          .catch((e) => {
-            console.warn('[AnswererNudge] FCM 푸시 실패:', e);
-          })
-      );
-    }
-  }
-  await Promise.all(answererPushTasks);
-
-  console.log(
-    `[AnswererNudge] Nudged ${answererUserMap.size} answerers across ${answererNudgedFamilyIds.size} families`
   );
 }
 

--- a/src/utils/i18n/push.ts
+++ b/src/utils/i18n/push.ts
@@ -22,6 +22,11 @@ interface PushMessages {
   answerReminder: { title: string; body: string; bodyMulti: (count: number) => string };
   nudge: { title: string; body: (senderName: string) => string };
   answererNudge: { title: string; body: (pendingCount: number) => string; bodyMulti: (questionCount: number) => string };
+  // MG-19: KST 19:00 스케줄 리마인더 — 답변자/미답변자 분기 문구
+  reminder: {
+    answered: { title: string; body: string };
+    unanswered: { title: string; body: string };
+  };
 }
 
 const messagesByLocale: Record<Locale, PushMessages> = {
@@ -48,6 +53,16 @@ const messagesByLocale: Record<Locale, PushMessages> = {
       body: (pending) => `아직 ${pending}명이 답변하지 않았어요. 접속해서 재촉해볼까요?`,
       bodyMulti: (questions) => `${questions}개의 질문에 아직 답 안 한 가족이 있어요. 재촉해볼까요?`,
     },
+    reminder: {
+      answered: {
+        title: '미답변자가 있어요',
+        body: '그룹에 접속해서 재촉하기를 해봐요',
+      },
+      unanswered: {
+        title: '오늘 질문에 답변하지 않았어요',
+        body: '그룹에 접속해서 답변을 달아봐요',
+      },
+    },
   },
   en: {
     newQuestion: {
@@ -72,6 +87,16 @@ const messagesByLocale: Record<Locale, PushMessages> = {
       body: (pending) => `${pending} family member${pending > 1 ? 's have' : ' has'} not answered yet. Send a nudge?`,
       bodyMulti: (questions) => `${questions} questions still need family answers. Nudge them now?`,
     },
+    reminder: {
+      answered: {
+        title: 'Someone has not answered yet',
+        body: 'Open the group and send a nudge',
+      },
+      unanswered: {
+        title: "You have not answered today's question",
+        body: 'Open the group and leave your answer',
+      },
+    },
   },
   ja: {
     newQuestion: {
@@ -95,6 +120,16 @@ const messagesByLocale: Record<Locale, PushMessages> = {
       title: '家族の回答を待っています',
       body: (pending) => `まだ${pending}人が回答していません。アプリを開いてリマインドを送りましょう`,
       bodyMulti: (questions) => `${questions}件の質問に未回答の家族がいます。リマインドを送りましょう`,
+    },
+    reminder: {
+      answered: {
+        title: '未回答の家族がいます',
+        body: 'グループに入ってリマインドを送りましょう',
+      },
+      unanswered: {
+        title: '今日の質問にまだ回答していません',
+        body: 'グループに入って回答してみましょう',
+      },
     },
   },
 };


### PR DESCRIPTION
## Jira / Issue
- Jira: [MG-19](https://ycompany.atlassian.net/browse/MG-19)
- Closes #14

## Summary
저녁 7시(KST 19:00) 리마인더 스케줄러가 스펙과 달리 **미답변자에게만 단일 메시지**로 발송하던 버그 수정. 그룹 내 미답변자가 1명 이상이면 **그룹 전원**에게 발송하고, 사용자별 답변 여부에 따라 title/body 를 분기. 클라이언트 라우팅용 `type=REMINDER` 부여.

## 변경 사항

### `src/reminderScheduler.ts` — sendDailyReminders
- 발송 대상: 미답변자 → **그룹 전원(답변자+미답변자)**
- 사용자별 메시지 분기:
  | 대상 | title | body |
  | --- | --- | --- |
  | 답변자 | 미답변자가 있어요 | 그룹에 접속해서 재촉하기를 해봐요 |
  | 미답변자 | 오늘 질문에 답변하지 않았어요 | 그룹에 접속해서 답변을 달아봐요 |
- DB Notification.type 및 FCM/APNs payload `type = "REMINDER"`
- 유저당 푸시 1회 / (유저, 가족) 단위 DB 알림 1건 — 기존 dedup 로직 유지
- `notifQuestion` 토글 존중 (false 시 푸시 skip, DB 알림은 저장)
- `skippedDate == dq.date` 멤버는 대상 제외 (기존 유지)

### MG-12 ANSWERER_NUDGE 통합
- 답변자 별도 경로는 REMINDER 의 답변자 분기로 승계 → **중복 푸시 방지**
- `ANSWERER_NUDGE` enum 값 및 `notifAnswererNudge` 필드는 하위호환을 위해 **유지** (UserService 선호도 API, 기존 DB 레코드 표시 등)

### 스키마 / i18n
- `NotificationType` enum 에 `REMINDER` 값 추가
  - 마이그레이션 SQL: `prisma/migrations/20260420100000_add_reminder_notification_type/migration.sql` (로컬 생성, gitignore. deploy 시 `prisma migrate deploy` 필요)
- `src/utils/i18n/push.ts`: `reminder.answered` / `reminder.unanswered` ko/en/ja 추가

### 회귀 방지 (건드리지 않음)
- `NudgeService` — 수동 재촉 (type=`ANSWER_REQUEST`)
- `AnswerService` — 답변완료 (type=`MEMBER_ANSWERED`)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과 (tsoa + tsc)
- [x] `npx jest` 전체 99/99 통과
- [x] `reminderScheduler.test.ts` 13/13 통과 — 아래 케이스 커버:
  - [x] 그룹 내 미답변자 0명이면 해당 그룹 skip
  - [x] 미답변자 1명 이상 → 답변자/미답변자 전원이 각자 메시지로 수신
  - [x] payload `type: "REMINDER"` 포함 (DB + APNs + FCM)
  - [x] 다중 가족 소속 유저 — 푸시 1회, DB 알림 가족별
  - [x] `notifQuestion=false` → DB 저장, 푸시 제외
  - [x] `skippedDate` 동일 날짜 → 제외
  - [x] FCM only / APNs only 토큰 케이스
- [ ] QA: 실제 디바이스에서 type=REMINDER 라우팅 확인 (iOS/Android 클라이언트 PR 선행 필요)
- [ ] QA: prod `prisma migrate deploy` 후 enum 반영 확인

## 참고
- 스케줄러 cron `0 10 * * ? *` (UTC 10:00 = KST 19:00) 변경 없음 (`serverless.yml:136-144`)
- 기존 코드 구조(배치 쿼리, KST 경계 보정) 유지 — 본 패치는 집계/분기 로직만 변경

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>