### PR TITLE
fix(push): APNs 환경을 토큰별로 저장하고 호스트를 선택 (MG-22)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,9 @@ model User {
   updatedAt          DateTime           @updatedAt @map("updated_at")
   moodId             String?            @default("loved") @map("mood_id")
   apnsToken          String?            @map("apns_token")
+  // iOS 빌드 환경에 따른 APNs 호스트 선택용. Debug 빌드는 sandbox, TestFlight/Store는 production.
+  // 토큰 등록 API에서 클라이언트가 함께 전달하며, 기존 레코드는 v1 배포 유저라 production default.
+  apnsEnvironment    ApnsEnvironment?   @default(production) @map("apns_environment")
   fcmToken           String?            @map("fcm_token")
   // Accept-Language 기반 사용자 선호 언어 (ko/en/ja). 서버가 푸시 알림 문구를 다국어로 선택할 때 사용.
   locale             String?            @map("locale")
@@ -207,4 +210,9 @@ enum NotificationType {
   ANSWERER_NUDGE
   BADGE_EARNED
   REMINDER
+}
+
+enum ApnsEnvironment {
+  sandbox
+  production
 }

--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -35,6 +35,7 @@ import { sendDailyReminders, getKstMidnightUtc } from '../reminderScheduler';
 const mockUser = {
   id: 'user-1',
   apnsToken: 'apns-token',
+  apnsEnvironment: 'production' as 'sandbox' | 'production' | null,
   fcmToken: null,
   locale: 'ko',
   notifQuestion: true,
@@ -111,7 +112,8 @@ describe('sendDailyReminders (MG-19)', () => {
       '오늘 질문에 답변하지 않았어요',
       '그룹에 접속해서 답변을 달아봐요',
       'REMINDER',
-      0
+      0,
+      'production'
     );
     expect(mockSendFcmPush).not.toHaveBeenCalled();
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -342,7 +342,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
       if (!userId) { res.status(400).json({ error: 'userId required' }); return; }
       const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { apnsToken: true, fcmToken: true },
+        select: { apnsToken: true, apnsEnvironment: true, fcmToken: true },
       });
       if (!user) { res.status(404).json({ error: 'user not found' }); return; }
 
@@ -351,7 +351,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
       const b = body ?? '이 알림이 보이면 APNs 경로는 정상입니다';
 
       const apnsResult = user.apnsToken
-        ? await pushService.sendApnsPushDiagnostic(user.apnsToken, t, b, 'ANSWER_REQUEST')
+        ? await pushService.sendApnsPushDiagnostic(user.apnsToken, t, b, 'ANSWER_REQUEST', user.apnsEnvironment)
         : { skipped: true, reason: 'no apnsToken' };
 
       res.json({

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -67,9 +67,9 @@ export class UserController extends Controller {
   @SuccessResponse(200, '성공')
   public async registerDeviceToken(
     @Request() req: AuthRequest,
-    @Body() body: { token: string }
+    @Body() body: { token: string; environment?: 'sandbox' | 'production' }
   ): Promise<{ ok: boolean }> {
-    await this.userService.registerDeviceToken(req.user.userId, body.token);
+    await this.userService.registerDeviceToken(req.user.userId, body.token, body.environment);
     return { ok: true };
   }
 

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -74,6 +74,7 @@ export async function sendDailyReminders(): Promise<void> {
         select: {
           id: true,
           apnsToken: true,
+          apnsEnvironment: true,
           fcmToken: true,
           locale: true,
           notifQuestion: true,
@@ -199,7 +200,8 @@ export async function sendDailyReminders(): Promise<void> {
             title,
             body,
             'REMINDER',
-            badgeCount
+            badgeCount,
+            user.apnsEnvironment
           );
         })().catch((e) => {
           console.warn('[Reminder] APNs 푸시 실패:', e);

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -21,7 +21,7 @@ export async function assignDailyQuestions(): Promise<void> {
   let assigned = 0;
 
   // 푸시 발송 대상을 유저 단위로 모아 중복 방지 (다중 그룹 소속 유저에게 1회만 발송)
-  const pushTargets = new Map<string, { apnsToken: string | null; fcmToken: string | null; locale: string | null; notifQuestion: boolean }>();
+  const pushTargets = new Map<string, { apnsToken: string | null; apnsEnvironment: 'sandbox' | 'production' | null; fcmToken: string | null; locale: string | null; notifQuestion: boolean }>();
   const dbNotifTasks: Promise<unknown>[] = [];
 
   for (const family of families) {
@@ -87,7 +87,7 @@ export async function assignDailyQuestions(): Promise<void> {
     // 가족 멤버 전원에게 DB 알림 저장 (그룹별 기록 유지) + 푸시 대상 수집
     const members = await prisma.user.findMany({
       where: { familyId: family.id },
-      select: { id: true, apnsToken: true, fcmToken: true, locale: true, notifQuestion: true },
+      select: { id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true, locale: true, notifQuestion: true },
     });
     for (const member of members) {
       const msgs = getPushMessages(member.locale);
@@ -105,6 +105,7 @@ export async function assignDailyQuestions(): Promise<void> {
       if (!pushTargets.has(member.id)) {
         pushTargets.set(member.id, {
           apnsToken: member.apnsToken,
+          apnsEnvironment: member.apnsEnvironment,
           fcmToken: member.fcmToken,
           locale: member.locale,
           notifQuestion: member.notifQuestion,
@@ -128,7 +129,7 @@ export async function assignDailyQuestions(): Promise<void> {
       pushTasks.push(
         (async () => {
           const badgeCount = await notificationService.getUnreadCount(userId);
-          await pushService.sendApnsPush(target.apnsToken!, title, body, 'NEW_QUESTION', badgeCount);
+          await pushService.sendApnsPush(target.apnsToken!, title, body, 'NEW_QUESTION', badgeCount, target.apnsEnvironment);
         })().catch((e) => {
           console.warn('[Scheduler] APNs 푸시 실패:', e);
         })

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -97,7 +97,7 @@ export class AnswerService {
 
       const otherMembers = await prisma.user.findMany({
         where: { familyId: user.familyId, id: { not: user.id } },
-        select: { id: true, apnsToken: true, fcmToken: true, locale: true, notifAnswer: true },
+        select: { id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true, locale: true, notifAnswer: true },
       });
 
       // Lambda에서는 fire-and-forget 패턴이 안 됨 — 핸들러가 응답하면 runtime이 frozen 처리되어
@@ -129,7 +129,7 @@ export class AnswerService {
           pushTasks.push(
             (async () => {
               const badgeCount = await notificationService.getUnreadCount(member.id);
-              await pushService.sendApnsPush(member.apnsToken!, title, body, 'MEMBER_ANSWERED', badgeCount);
+              await pushService.sendApnsPush(member.apnsToken!, title, body, 'MEMBER_ANSWERED', badgeCount, member.apnsEnvironment);
             })().catch((e) => {
               console.warn('[Answer] APNs 푸시 실패:', e);
             })

--- a/src/services/NudgeService.ts
+++ b/src/services/NudgeService.ts
@@ -78,7 +78,7 @@ export class NudgeService {
         pushTasks.push(
           (async () => {
             const badgeCount = await notificationService.getUnreadCount(target.id);
-            await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount);
+            await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment);
           })().catch((e) => {
             console.warn('[Nudge] APNs 푸시 실패:', e);
           })

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -75,14 +75,23 @@ export class PushNotificationService {
     }
   }
 
-  /** APNs 푸시 알림 범용 발송 */
-  async sendApnsPush(deviceToken: string, title: string, body: string, type: string, badgeCount?: number): Promise<void> {
+  /** APNs 푸시 알림 범용 발송.
+   * environment: 'sandbox' | 'production' — 유저 레코드에 저장된 값을 그대로 전달.
+   * 미지정(undefined/null) 시 서버의 NODE_ENV 기반 fallback을 사용. (MG-22) */
+  async sendApnsPush(
+    deviceToken: string,
+    title: string,
+    body: string,
+    type: string,
+    badgeCount?: number,
+    environment?: 'sandbox' | 'production' | null
+  ): Promise<void> {
     if (!this.keyId || !this.teamId || !this.bundleId || !this.rawKey) return;
     const payload = JSON.stringify({
       aps: { alert: { title, body }, sound: 'default', badge: badgeCount ?? 1 },
       type,
     });
-    return this._sendApnsPayload(deviceToken, payload);
+    return this._sendApnsPayload(deviceToken, payload, environment);
   }
 
   /**
@@ -97,7 +106,13 @@ export class PushNotificationService {
    *   - isProduction: 서버가 스스로 production으로 판단했는지
    *   - skipped: 환경변수 미설정으로 발송 자체를 못한 경우
    */
-  async sendApnsPushDiagnostic(deviceToken: string, title: string, body: string, type: string): Promise<{
+  async sendApnsPushDiagnostic(
+    deviceToken: string,
+    title: string,
+    body: string,
+    type: string,
+    environment?: 'sandbox' | 'production' | null
+  ): Promise<{
     ok: boolean;
     status?: number;
     body?: string;
@@ -106,20 +121,21 @@ export class PushNotificationService {
     skipped?: boolean;
     error?: string;
   }> {
+    const isProduction = environment ? environment === 'production' : this.isProduction;
     if (!this.keyId || !this.teamId || !this.bundleId || !this.rawKey) {
-      return { ok: false, isProduction: this.isProduction, skipped: true, error: 'APNs env vars not set' };
+      return { ok: false, isProduction, skipped: true, error: 'APNs env vars not set' };
     }
     const payload = JSON.stringify({
       aps: { alert: { title, body }, sound: 'default', badge: 1 },
       type,
     });
-    const host = this.isProduction ? 'api.push.apple.com' : 'api.sandbox.push.apple.com';
+    const host = isProduction ? 'api.push.apple.com' : 'api.sandbox.push.apple.com';
     return new Promise((resolve) => {
       try {
         const client = http2.connect(`https://${host}`, { rejectUnauthorized: true });
         client.on('error', (e) => {
           client.destroy();
-          resolve({ ok: false, host, isProduction: this.isProduction, error: `connect error: ${String(e)}` });
+          resolve({ ok: false, host, isProduction, error: `connect error: ${String(e)}` });
         });
         const headers: http2.OutgoingHttpHeaders = {
           ':method': 'POST',
@@ -141,37 +157,48 @@ export class PushNotificationService {
         req.on('data', (chunk: Buffer) => { respBody += chunk.toString(); });
         req.on('end', () => {
           client.close();
-          resolve({ ok: status === 200, status, body: respBody, host, isProduction: this.isProduction });
+          resolve({ ok: status === 200, status, body: respBody, host, isProduction });
         });
         req.on('error', (e) => {
           client.destroy();
-          resolve({ ok: false, status, body: respBody, host, isProduction: this.isProduction, error: `request error: ${String(e)}` });
+          resolve({ ok: false, status, body: respBody, host, isProduction, error: `request error: ${String(e)}` });
         });
         req.write(payload);
         req.end();
       } catch (e) {
-        resolve({ ok: false, host, isProduction: this.isProduction, error: `exception: ${String(e)}` });
+        resolve({ ok: false, host, isProduction, error: `exception: ${String(e)}` });
       }
     });
   }
 
   /** 재촉하기 푸시 알림 발송 */
-  async sendNudgePush(deviceToken: string, senderName: string, badgeCount?: number): Promise<void> {
+  async sendNudgePush(
+    deviceToken: string,
+    senderName: string,
+    badgeCount?: number,
+    environment?: 'sandbox' | 'production' | null
+  ): Promise<void> {
     const payload = JSON.stringify({
       aps: { alert: { title: '재촉하기 알림', body: `${senderName}님이 오늘의 질문에 답변해달라고 합니다` }, sound: 'default', badge: badgeCount ?? 1 },
       type: 'ANSWER_REQUEST',
     });
-    return this._sendApnsPayload(deviceToken, payload);
+    return this._sendApnsPayload(deviceToken, payload, environment);
   }
 
-  /** APNs HTTP/2 공통 발송 */
-  private _sendApnsPayload(deviceToken: string, payload: string): Promise<void> {
+  /** APNs HTTP/2 공통 발송.
+   * environment 지정 시 토큰별로 sandbox/production 호스트 선택. 미지정 시 서버 NODE_ENV fallback. (MG-22) */
+  private _sendApnsPayload(
+    deviceToken: string,
+    payload: string,
+    environment?: 'sandbox' | 'production' | null
+  ): Promise<void> {
     if (!this.keyId || !this.teamId || !this.bundleId || !this.rawKey) {
       console.warn('[APNs] 환경변수 미설정 — 푸시 발송 건너뜀 (APNS_KEY_ID/TEAM_ID/BUNDLE_ID/PRIVATE_KEY)');
       return Promise.resolve();
     }
 
-    const host = this.isProduction ? 'api.push.apple.com' : 'api.sandbox.push.apple.com';
+    const isProduction = environment ? environment === 'production' : this.isProduction;
+    const host = isProduction ? 'api.push.apple.com' : 'api.sandbox.push.apple.com';
 
     return new Promise<void>((resolve) => {
       try {
@@ -225,7 +252,7 @@ export class PushNotificationService {
     const prisma = (await import('../utils/prisma')).default;
     const result = await prisma.user.updateMany({
       where: { apnsToken: token },
-      data: { apnsToken: null },
+      data: { apnsToken: null, apnsEnvironment: null },
     });
     if (result.count > 0) {
       console.warn(`[APNs] 만료 토큰 정리 완료 — ${result.count}명의 토큰 제거 (token=${token.substring(0, 8)}...)`);

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -217,7 +217,7 @@ export class UserService {
    * APNs 디바이스 토큰 저장/갱신
    * 동일 토큰을 보유한 다른 유저가 있으면 해당 유저의 토큰을 null 처리 (중복 푸시 방지)
    */
-  async registerDeviceToken(userId: string, token: string): Promise<void> {
+  async registerDeviceToken(userId: string, token: string, environment?: 'sandbox' | 'production'): Promise<void> {
     if (!token) throw Errors.badRequest('디바이스 토큰이 비어 있습니다.');
     const user = await prisma.user.findUnique({ where: { userId } });
     if (!user) throw Errors.notFound('사용자');
@@ -225,10 +225,14 @@ export class UserService {
     // 동일 APNs 토큰을 가진 다른 유저의 토큰 제거 (디바이스 1대 = 토큰 1개 원칙)
     await prisma.user.updateMany({
       where: { apnsToken: token, id: { not: user.id } },
-      data: { apnsToken: null },
+      data: { apnsToken: null, apnsEnvironment: null },
     });
 
-    await prisma.user.update({ where: { id: user.id }, data: { apnsToken: token } });
+    // environment 미지정 시(구형 클라이언트) production 가정 — v1 배포 유저의 하위호환 경로.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { apnsToken: token, apnsEnvironment: environment ?? 'production' },
+    });
   }
 
   /**


### PR DESCRIPTION
## Jira
- [MG-22](https://ycompany.atlassian.net/browse/MG-22)

## Related
- iOS 대응 PR (rrheon/Mongle)

## Summary
- Prisma: User.apnsEnvironment 컬럼(enum sandbox/production, default production) 추가, v1 유저 하위호환
- PATCH /users/me/device-token body 에 environment 필드 추가, UserService.registerDeviceToken 이 저장
- PushNotificationService 전 발송 메서드(sendApnsPush/sendNudgePush/sendApnsPushDiagnostic/_sendApnsPayload)에 environment 파라미터. 미지정 시 NODE_ENV fallback
- 발송 경로 5곳(scheduler / reminderScheduler / AnswerService / NudgeService / app.ts 진단) 모두 user.apnsEnvironment 전달
- invalidateApnsToken 이 토큰 무효화 시 apnsEnvironment 도 함께 null 처리

## 배포 순서 (필수)
1. prisma/migrations/20260421032900_add_apns_environment/migration.sql 을 DB에 적용 — 이 레포는 migrations 를 .gitignore 하므로 수동 배포 필요 (prisma migrate deploy 또는 psql 직접 실행)
2. serverless deploy --stage prod

## Test plan
- [ ] npm test (기존 99 테스트 pass)
- [ ] npx tsc --noEmit (타입 오류 0)
- [ ] Debug 빌드 등록 후 Lambda invoke → CloudWatch 에서 sandbox 호스트 확인
- [ ] TestFlight 빌드 등록 후 Lambda invoke → production 호스트 확인
- [ ] 기존 유저(apnsEnvironment=null) → production fallback 정상 발송

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)