### PR TITLE
fix(reminder): 가족별 활성 DQ 1개만 대상으로 변경 (7일 윈도우 제거)

### DIFF
--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -7,9 +7,7 @@ import { getPushMessages } from './utils/i18n/push';
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
 
-export const REMINDER_WINDOW_DAYS = 7;
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
  * 현재 시점의 KST 자정을 UTC Date 로 반환.
@@ -34,9 +32,12 @@ function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boo
  * MG-19: 저녁 7시 리마인더 알림 (KST 19:00 스케줄, type=REMINDER).
  *
  * 조건:
- *   - 최근 REMINDER_WINDOW_DAYS 이내 배정된 모든 DailyQuestion
- *   - 가족 내 미답변 멤버가 1명 이상일 때에만 해당 가족을 리마인드 대상으로 포함
- *   - 발송 대상은 **그룹 전원** (답변자 + 미답변자) — 클라이언트에서 type=REMINDER 로 라우팅
+ *   - 대상은 각 가족의 **현재 활성(가장 최근 배정) DailyQuestion 1개** — MG-16 의
+ *     carry-over 정책(자동교체 없음, 최신 DQ 무기한 유지)과 일관됨.
+ *     이전 버전(7일 윈도우)은 과거 미답변 질문까지 미답변자 문구로 묶여서 "오늘 그룹
+ *     전원 답변했는데 왜 답변 안 했다고 나오지?"라는 UX 혼란을 유발했다.
+ *   - 해당 활성 DQ 에서 미답변 멤버가 1명 이상일 때에만 리마인드 대상 가족으로 포함.
+ *   - 발송 대상은 **그룹 전원** (답변자 + 미답변자) — 클라이언트에서 type=REMINDER 로 라우팅.
  *   - 메시지 분기 (사용자별 해당 가족의 오늘 답변 여부 기준):
  *       · 답변자:   title "미답변자가 있어요" / body "그룹에 접속해서 재촉하기를 해봐요"
  *       · 미답변자: title "오늘 질문에 답변하지 않았어요" / body "그룹에 접속해서 답변을 달아봐요"
@@ -50,15 +51,18 @@ function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boo
  */
 export async function sendDailyReminders(): Promise<void> {
   const kstMidnight = getKstMidnightUtc();
-  const windowStart = new Date(kstMidnight.getTime() - REMINDER_WINDOW_DAYS * DAY_MS);
 
+  // 각 가족의 활성(가장 최근) DQ 1건만 후보로 선정.
+  // Prisma distinct + orderBy 로 PostgreSQL DISTINCT ON (family_id) 유사 동작.
+  // where 에서 미래 DQ 제외(이론상 없지만 안전장치).
   const candidateDQs = await prisma.dailyQuestion.findMany({
-    where: { date: { gte: windowStart } },
-    orderBy: { date: 'desc' },
+    where: { date: { lte: kstMidnight } },
+    distinct: ['familyId'],
+    orderBy: [{ familyId: 'asc' }, { date: 'desc' }],
     select: { id: true, questionId: true, familyId: true, date: true },
   });
   if (candidateDQs.length === 0) {
-    console.log('[Reminder] No candidate questions in window');
+    console.log('[Reminder] No active DQs found');
     return;
   }
 


### PR DESCRIPTION
## 버그 리포트
7시 리마인더에서 "zxx 그룹은 그룹내 인원이 모두 답변했는데 오늘 질문에 답변하지않았어요 알림이 왔어" — 그룹 전원 답변 완료 상태에서 미답변자 문구 푸시/DB 알림이 수신됨.

## 원인
\`reminderScheduler.ts\`의 \`REMINDER_WINDOW_DAYS = 7\` 로 최근 7일 내 모든 DQ를 후보로 돌며 \`existing.userUnanswered = true\` 로 덮어쓰기 때문에, **오늘은 전원 답변 완료여도 과거 7일 내 미답변 DQ 1건이 있으면** 해당 가족이 발송 대상이 되고 "답변하지 않았어요" 문구가 쓰임.

## 변경
- \`REMINDER_WINDOW_DAYS\`/\`DAY_MS\` 상수 제거
- \`findMany\` 쿼리를 \`distinct: ['familyId']\` + \`orderBy [familyId asc, date desc]\` 로 변경
  - PostgreSQL \`DISTINCT ON (family_id)\` 유사 동작으로 각 가족의 **활성(가장 최근) DQ 1건**만 후보로 선정
- MG-16 carry-over 정책(자동교체 없음, 최신 DQ 무기한 유지)과 일관

## Test plan
- [x] \`npx jest src/__tests__/reminderScheduler.test.ts\` — 13건 전체 통과
- [ ] 배포 후 \`npx serverless invoke --function dailyReminderScheduler --stage prod --log\` 수동 실행하여 로그상 "Reminded N unique users across M families" 에서 **M 이 이전보다 감소**(과거 미답변 가족 제외)하는지 확인
- [ ] 실기기: 오늘 전원 답변 완료된 그룹에서 더 이상 "답변하지 않았어요" 푸시가 오지 않는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)