### PR TITLE
fix(reminder): 오늘 배정된 DQ 누락 버그 수정

### DIFF
--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -50,13 +50,14 @@ function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boo
  * 수동 재촉(NudgeService → type ANSWER_REQUEST) 및 답변완료(MEMBER_ANSWERED) 경로는 변경 없음.
  */
 export async function sendDailyReminders(): Promise<void> {
-  const kstMidnight = getKstMidnightUtc();
-
   // 각 가족의 활성(가장 최근) DQ 1건만 후보로 선정.
   // Prisma distinct + orderBy 로 PostgreSQL DISTINCT ON (family_id) 유사 동작.
-  // where 에서 미래 DQ 제외(이론상 없지만 안전장치).
+  // 날짜 상한을 두지 않는 이유:
+  //   - DailyQuestion.date 는 @db.Date 라 DB 값이 `YYYY-MM-DD T00:00:00Z`(UTC 자정)
+  //   - getKstMidnightUtc() 는 "KST 자정의 UTC 시각" 이라 `YYYY-MM-DD-1 T15:00:00Z`
+  //   - 두 값을 lte 로 비교하면 **오늘 배정된 DQ 가 제외**되는 off-by-one 발생
+  //   - 미래 DQ 는 현재 발행 정책상 존재하지 않으므로 상한 불필요
   const candidateDQs = await prisma.dailyQuestion.findMany({
-    where: { date: { lte: kstMidnight } },
     distinct: ['familyId'],
     orderBy: [{ familyId: 'asc' }, { date: 'desc' }],
     select: { id: true, questionId: true, familyId: true, date: true },


### PR DESCRIPTION
## 버그
PR #20 핫픽스에서 \`where: { date: { lte: kstMidnight } }\` 추가. 하지만:
- \`DailyQuestion.date\` (@db.Date) → DB 저장값 \`2026-04-22T00:00:00Z\`
- \`getKstMidnightUtc()\` → \`2026-04-21T15:00:00Z\`
- \`lte\` 비교 → 오늘 배정된 DQ **전체 제외** (off-by-one)

결과: 오늘 배정 가족(carry-over 아닌 오늘 신규 발행)에 대한 리마인더가 **전부 누락**. 사용자가 속한 "오늘 배정" 그룹엔 DB 알림/푸시 모두 안 옴.

## 수정
\`where\` 절 완전 제거. \`distinct + orderBy\` 만으로 가족별 최신 DQ 1건 선정. 미래 DQ 는 발행 정책상 존재하지 않아 상한 불요.

## 검증
- \`npx jest src/__tests__/reminderScheduler.test.ts\` — 13건 전체 통과
- 로컬 재실행: 8 families → 11 families (오늘 배정 포함 확인)
- 특정 유저 DB 알림: 0건 → 2건 (본인 미답변 가족만 정확히 저장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)