### PR TITLE
fix(notify): NEW_QUESTION/MEMBER_ANSWERED 알림 멤버 조회 불일치 수정 (MG-29)

### DIFF
--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -95,10 +95,18 @@ export class AnswerService {
       const senderNickname = senderMembership?.nickname ?? user.name;
       const senderColorId = senderMembership?.colorId ?? data.moodId ?? 'loved';
 
-      const otherMembers = await prisma.user.findMany({
-        where: { familyId: user.familyId, id: { not: user.id } },
-        select: { id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true, locale: true, notifAnswer: true },
+      // FamilyMembership 기반 조회 — User.familyId 는 "현재 활성 가족" 1개만 가리키므로,
+      // 멤버가 다른 그룹을 활성으로 두면 매칭 0건이 되어 MEMBER_ANSWERED 알림이 누락되던
+      // 버그(MG-29) 수정. 본인 제외는 userId 비교로 처리.
+      const otherMemberships = await prisma.familyMembership.findMany({
+        where: { familyId: user.familyId, userId: { not: user.id } },
+        select: {
+          user: {
+            select: { id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true, locale: true, notifAnswer: true },
+          },
+        },
       });
+      const otherMembers = otherMemberships.map((m) => m.user);
 
       // Lambda에서는 fire-and-forget 패턴이 안 됨 — 핸들러가 응답하면 runtime이 frozen 처리되어
       // 백그라운드 HTTP/2 APNs 연결이 중단됨. 모든 푸시 작업을 await 처리.

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -623,17 +623,25 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
   const notifSvc = new NotificationService();
   const pushSvc = new PushNotificationService();
 
-  const members = await prisma.user.findMany({
+  // FamilyMembership 기반 조회 — User.familyId 단일 컬럼은 유저의 "현재 활성 가족" 1개만
+  // 가리키므로, 멤버가 다른 그룹을 활성으로 두면 매칭 0건이 되어 알림이 누락되던 버그(MG-29)
+  // 수정. 스케줄러(scheduler.ts)·리마인더(reminderScheduler.ts)와 동일한 N:M 진실 사용.
+  const memberships = await prisma.familyMembership.findMany({
     where: { familyId },
     select: {
-      id: true,
-      apnsToken: true,
-      apnsEnvironment: true,
-      fcmToken: true,
-      locale: true,
-      notifQuestion: true,
+      user: {
+        select: {
+          id: true,
+          apnsToken: true,
+          apnsEnvironment: true,
+          fcmToken: true,
+          locale: true,
+          notifQuestion: true,
+        },
+      },
     },
   });
+  const members = memberships.map((m) => m.user);
 
   const tasks: Promise<unknown>[] = [];
   for (const m of members) {

--- a/src/services/__tests__/AnswerService.test.ts
+++ b/src/services/__tests__/AnswerService.test.ts
@@ -120,7 +120,8 @@ const mockAnswerWithUser = {
 function setupCreateAnswerSuccessPath() {
   mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id' });
   mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ nickname: null, colorId: 'loved' });
-  mockPrismaUserFindMany.mockResolvedValue([]); // 다른 가족 멤버 없음 → 알림/푸시 루프 생략
+  // MG-29: prisma.user.findMany → familyMembership.findMany 로 변경됨. 빈 멤버십 = 알림/푸시 루프 생략.
+  mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([]);
 }
 
 describe('AnswerService.createAnswer', () => {

--- a/src/services/__tests__/QuestionService.test.ts
+++ b/src/services/__tests__/QuestionService.test.ts
@@ -51,6 +51,23 @@ jest.mock('../../utils/prisma', () => ({
   },
 }));
 
+const mockCreateNotification = jest.fn();
+const mockGetUnreadCount = jest.fn().mockResolvedValue(0);
+const mockSendApnsPush = jest.fn().mockResolvedValue(undefined);
+const mockSendFcmPush = jest.fn().mockResolvedValue(undefined);
+jest.mock('../NotificationService', () => ({
+  NotificationService: jest.fn().mockImplementation(() => ({
+    createNotification: mockCreateNotification,
+    getUnreadCount: mockGetUnreadCount,
+  })),
+}));
+jest.mock('../PushNotificationService', () => ({
+  PushNotificationService: jest.fn().mockImplementation(() => ({
+    sendApnsPush: mockSendApnsPush,
+    sendFcmPush: mockSendFcmPush,
+  })),
+}));
+
 import { QuestionService } from '../QuestionService';
 
 const service = new QuestionService();
@@ -283,6 +300,40 @@ describe('QuestionService.createCustomQuestion', () => {
         data: { hearts: { decrement: 3 } },
       })
     );
+  });
+});
+
+describe('notifyNewQuestion (MG-29 회귀)', () => {
+  beforeEach(() => {
+    mockCreateNotification.mockReset().mockResolvedValue(undefined);
+    mockSendApnsPush.mockClear();
+    mockSendFcmPush.mockClear();
+    mockPrismaUserFindMany.mockClear();
+    mockPrismaFamilyMembershipFindMany.mockReset();
+  });
+
+  it('FamilyMembership 기반으로 멤버를 조회한다 — User.familyId 단일 컬럼 조회 회귀 방지', async () => {
+    // 가족 family-A 의 멤버 2명. 한 명(u2)은 활성 가족이 다른 그룹(B) 이지만
+    // family-A 의 FamilyMembership 행은 존재하므로 알림 대상에 포함되어야 한다.
+    mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([
+      { user: { id: 'u1', apnsToken: 'tok-a', apnsEnvironment: 'sandbox', fcmToken: null, locale: 'ko', notifQuestion: true } },
+      { user: { id: 'u2', apnsToken: 'tok-b', apnsEnvironment: 'production', fcmToken: null, locale: 'ko', notifQuestion: true } },
+    ]);
+
+    const { notifyNewQuestion } = await import('../QuestionService');
+    await notifyNewQuestion('family-A');
+
+    // 잘못된 단일 컬럼 조회 경로가 다시 들어오지 않았는지 (회귀 방지의 핵심)
+    expect(mockPrismaUserFindMany).not.toHaveBeenCalled();
+
+    // 올바른 N:M 조회가 호출됐는지
+    expect(mockPrismaFamilyMembershipFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { familyId: 'family-A' } })
+    );
+
+    // 멤버 2명 모두에게 인앱 알림 + APNs 푸시 발송됐는지
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Jira
- [MG-29](https://ycompany.atlassian.net/browse/MG-29)

## Summary
- `User.familyId` 단일 컬럼 조회는 멀티 가족 소속 케이스에서 매칭 0건 → 알림 루프 0회 실행. 스케줄러·리마인더와 동일하게 `FamilyMembership(N:M)` 기반으로 통일.
- `QuestionService.notifyNewQuestion`, `AnswerService.createAnswer otherMembers` 두 곳 수정.
- 회귀 방지 테스트 1건 추가 (멀티 가족 멤버 케이스, 잘못된 쿼리 호출 0회 검증). 전체 100/100 통과.

## 영향 범위
| 알림 | 영향 |
|---|---|
| NEW_QUESTION (오전 11시 배정) | 수정 |
| MEMBER_ANSWERED (멤버 답변 시) | 수정 |
| REMINDER (오후 7시) | 영향 없음 |
| ANSWER_REQUEST (재촉) | 영향 없음 |

## Test plan
- [ ] 두 가족(A, B) 소속 유저(활성=B)에 대해 A의 새 질문 배정 → 인앱+APNs/FCM 도착
- [ ] 동일 조건에서 A 멤버 답변 시 MEMBER_ANSWERED 가 본인 제외 전원에게 도착
- [ ] 단일 가족 케이스 회귀 없음
- [ ] 리마인더·재촉 회귀 없음

## Follow-up (별도 티켓 후보)
- `AnswerService.ts:240-242` 의 답변 조회(`answer.findMany with user.familyId`) — 같은 단일 활성 가족 한계 패턴이지만 read 영역이라 본 PR 범위 외.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)