### PR TITLE
fix(scheduler): dev stage cron 비활성화 (MG-30)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,6 +100,13 @@ custom:
   nodeEnv:
     prod: production
     dev: development
+  # MG-30: cron(EventBridge) 스케줄은 prod stage에서만 활성화.
+  # 사유: .env 파일이 stage 공용(prod RDS)이라 dev Lambda가 cron으로 돌면
+  # dev + prod 두 Lambda가 같은 prod DB로 리마인더/배정을 각각 실행 → 2회 중복.
+  # dev 수동 검증은 `npx serverless invoke --stage dev --function <name>` 사용.
+  schedulerEnabled:
+    prod: true
+    dev: false
 
 functions:
   # Main API Handler
@@ -125,23 +132,25 @@ functions:
           path: /docs/{proxy+}
 
   # 매일 오전 질문 배정 스케줄러 (KST 11:00 = UTC 02:00)
+  # enabled: MG-30 — prod에서만 활성화 (dev는 .env가 prod DB라 중복 실행 방지)
   dailyQuestionScheduler:
     handler: src/scheduler.handler
     timeout: 60
     events:
       - schedule:
           rate: cron(0 2 * * ? *)
-          enabled: true
+          enabled: ${self:custom.schedulerEnabled.${self:provider.stage}, false}
 
   # 매일 저녁 자동 재촉 알림 (KST 19:00 = UTC 10:00)
   # 각 가족의 현재 활성 질문에 대해 아직 답/패스 안 한 멤버에게 1회 푸시 (날짜 무관)
+  # enabled: MG-30 — prod에서만 활성화
   dailyReminderScheduler:
     handler: src/reminderScheduler.handler
     timeout: 60
     events:
       - schedule:
           rate: cron(0 10 * * ? *)
-          enabled: true
+          enabled: ${self:custom.schedulerEnabled.${self:provider.stage}, false}
 
 # 리소스 정의 (선택사항 - 별도 CloudFormation으로 관리 권장)
 # resources:


### PR DESCRIPTION
## Jira
- [MG-30](https://ycompany.atlassian.net/browse/MG-30)

## Summary
- 매일 KST 19:00 리마인더가 가족당 2건씩 중복 발송되는 버그 핫픽스.
- 원인: .env 공용으로 dev/prod Lambda 모두 같은 prod DB 조회 + cron `enabled:true` 고정으로 양쪽 트리거.
- 해결: `custom.schedulerEnabled` stage 플래그 신설, 두 cron의 enabled를 stage 조건부로.

## Test plan
- [ ] `npx serverless print --stage dev` → 두 cron 모두 `enabled: false`
- [ ] `npx serverless print --stage prod` → 두 cron 모두 `enabled: true`
- [ ] `npm run deploy:dev` 후 AWS 콘솔 EventBridge에서 `famtree-api-dev-dailyReminderScheduler*` 규칙 비활성/삭제 확인
- [ ] `npm run deploy:prod` 후 `famtree-api-prod-*Scheduler*` 규칙 active 유지, next invocation KST 19:00
- [ ] 익일 실기기(mrdydgjs@naver.com 등) KST 19:00 리마인더 1건만 수신
- [ ] `Notification` 테이블 동일 분 내 (userId, familyId, type=REMINDER) 중복 0건

## Follow-up
- `.env.dev`/`.env.prod` 분리 + dev 전용 RDS (근본 해결)
- `notifyNewQuestion` Notification 멱등성 보강

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)