### PR TITLE
fix(server): getFamilyAnswers FamilyMembership + DQ race (MG-40)

### DIFF
--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -231,6 +231,10 @@ export class AnswerService {
     const colorMap = new Map(
       memberships.map((m) => [m.userId, m.colorId ?? m.user.moodId ?? 'loved'])
     );
+    // FamilyMembership 기반 멤버 ID 집합. user.familyId 단일 활성 그룹 필드는
+    // 다대다 전환 이후 답변 조회 기준으로 부정확 (그룹 이동/중복 가입 시 누락).
+    // MG-29 (멤버 조회) 와 동일 패턴을 답변 조회에도 적용.
+    const memberUserIds = memberships.map((m) => m.userId);
 
     // 해당 질문의 DailyQuestion 조회 (skip 날짜 비교용)
     const dailyQuestion = await prisma.dailyQuestion.findFirst({
@@ -245,9 +249,7 @@ export class AnswerService {
     const answers = await prisma.answer.findMany({
       where: {
         questionId: questionId.toLowerCase(),
-        user: {
-          familyId: user.familyId,
-        },
+        userId: { in: memberUserIds },
       },
       include: { user: true },
       orderBy: { createdAt: 'asc' },

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -487,14 +487,35 @@ export class QuestionService {
 
     const selected = questionPool[Math.floor(Math.random() * questionPool.length)];
 
-    const created = await prisma.dailyQuestion.create({
-      data: { questionId: selected.id, familyId, date },
-      include: { question: true },
-    });
+    // (familyId, date) 는 unique 제약. 스케줄러/getTodayQuestion/FamilyService 진입점이
+    // 동시에 발화하면 check-then-create 사이에 race 가 발생하여 P2002 → 500 으로 노출된다.
+    // create 실패 시 기존 DQ 를 재조회해 동일하게 NEW_QUESTION 알림까지 진행한다.
+    let created;
+    let isNewlyCreated = false;
+    try {
+      created = await prisma.dailyQuestion.create({
+        data: { questionId: selected.id, familyId, date },
+        include: { question: true },
+      });
+      isNewlyCreated = true;
+    } catch (e: any) {
+      if (e?.code === 'P2002') {
+        const existing = await prisma.dailyQuestion.findUnique({
+          where: { familyId_date: { familyId, date } },
+          include: { question: true },
+        });
+        if (!existing) throw e;
+        created = existing;
+      } else {
+        throw e;
+      }
+    }
 
-    await notifyNewQuestion(familyId).catch((e) => {
-      console.warn(`[QuestionService] NEW_QUESTION 알림 실패 family=${familyId}:`, e);
-    });
+    if (isNewlyCreated) {
+      await notifyNewQuestion(familyId).catch((e) => {
+        console.warn(`[QuestionService] NEW_QUESTION 알림 실패 family=${familyId}:`, e);
+      });
+    }
 
     return created;
   }


### PR DESCRIPTION
## Jira
- [MG-40](https://ycompany.atlassian.net/browse/MG-40)

## Related
- 1차 audit Server PR: #27 (MG-36 history displayDate, 머지+prod 배포 완료)
- 동일 패턴 선행: MG-29 (멤버 조회 fix, PR #23)

## Summary
- AnswerService.getFamilyAnswers: `where.user.familyId` → `userId in memberUserIds` (FamilyMembership 기반). MG-29 동일 패턴 잔여 코드 정리.
- QuestionService.assignQuestionToFamily: `dailyQuestion.create` 실패(P2002) 시 `findUnique({familyId_date})` 폴백. NEW_QUESTION 중복 알림 방지 플래그 추가.
- type-check 통과 (`tsc --noEmit`).

## Test plan
- [ ] 그룹 전환 사용자: 다른 그룹 답변이 현재 그룹 답변 목록에 안 섞이는지
- [ ] 스케줄러 + getTodayQuestion 동시 호출: DQ 1개만 생성, 두 번째 호출은 기존 DQ 반환
- [ ] 가족 생성 직후 첫 질문 발급 정상
- [ ] NEW_QUESTION 푸시 1회만 발송 (race 두 번째 경로에서 중복 발송 안 됨)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)