### PR TITLE
fix(server): APNs 400 reason + NEW_QUESTION 2-stage (MG-41)

### DIFF
--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -225,8 +225,26 @@ export class PushNotificationService {
             req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
             req.on('end', () => {
               console.error(`[APNs] 푸시 실패 status=${status} token=${deviceToken.substring(0, 8)}...`, body);
-              // 410 Gone = 토큰이 더 이상 유효하지 않음 → DB에서 자동 정리
-              if (status === 410 || status === 400) {
+              // 410 Gone = 토큰 만료/미설치. 항상 무효화.
+              // 400 Bad Request 는 토큰 외 사유(BadCertificate, BadTopic, BadMessageId,
+              // BadPriority 등 페이로드/설정 오류)도 포함되므로 reason 을 확인해
+              // 토큰-invalid 류만 정리. reason 미상이면 안전 측 보존.
+              const tokenInvalidReasons = new Set([
+                'BadDeviceToken',
+                'Unregistered',
+                'DeviceTokenNotForTopic',
+                'TopicDisallowed',
+              ]);
+              let shouldInvalidate = status === 410;
+              if (status === 400) {
+                try {
+                  const reason = (JSON.parse(body) as { reason?: string }).reason;
+                  if (reason && tokenInvalidReasons.has(reason)) shouldInvalidate = true;
+                } catch {
+                  // body 파싱 실패 시 토큰 손상 단정 불가 → 보존
+                }
+              }
+              if (shouldInvalidate) {
                 this.invalidateApnsToken(deviceToken).catch((e) => {
                   console.error('[APNs] 토큰 무효화 실패:', e);
                 });

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -648,22 +648,31 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
   });
   const members = memberships.map((m) => m.user);
 
-  const tasks: Promise<unknown>[] = [];
+  // 1단계: DB 알림 저장 — 푸시의 badge 카운트가 새 알림을 포함해 정확히 반영되도록
+  // 모든 createNotification 을 먼저 await. AnswerService.MEMBER_ANSWERED 와 동일 패턴.
+  const dbNotifTasks: Promise<unknown>[] = [];
   for (const m of members) {
     const msgs = getPushMessages(m.locale);
     const title = msgs.newQuestion.title;
     const body = msgs.newQuestion.body;
-
-    tasks.push(
+    dbNotifTasks.push(
       notifSvc.createNotification(m.id, 'NEW_QUESTION', title, body, familyId).catch((e) => {
         console.warn(`[notifyNewQuestion] DB 알림 실패 user=${m.id} family=${familyId}:`, e);
       })
     );
+  }
+  await Promise.all(dbNotifTasks);
 
+  // 2단계: 푸시 발송 (DB 알림 반영된 unread 카운트 사용)
+  const pushTasks: Promise<unknown>[] = [];
+  for (const m of members) {
     if (!m.notifQuestion) continue;
+    const msgs = getPushMessages(m.locale);
+    const title = msgs.newQuestion.title;
+    const body = msgs.newQuestion.body;
 
     if (m.apnsToken) {
-      tasks.push(
+      pushTasks.push(
         (async () => {
           const badge = await notifSvc.getUnreadCount(m.id);
           await pushSvc.sendApnsPush(m.apnsToken!, title, body, 'NEW_QUESTION', badge, m.apnsEnvironment);
@@ -673,14 +682,14 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
       );
     }
     if (m.fcmToken) {
-      tasks.push(
+      pushTasks.push(
         pushSvc.sendFcmPush(m.fcmToken, title, body, 'NEW_QUESTION').catch((e) => {
           console.warn(`[notifyNewQuestion] FCM 실패 user=${m.id}:`, e);
         })
       );
     }
   }
-  await Promise.all(tasks);
+  await Promise.all(pushTasks);
 }
 
 export { notifyNewQuestion };


### PR DESCRIPTION
## Jira
- [MG-41](https://ycompany.atlassian.net/browse/MG-41)

## Related
- 동일 패턴 선행: AnswerService MEMBER_ANSWERED 2-stage (MG-29 PR #23 에서 정착)

## Summary
- APNs 400 응답: reason 파싱 후 토큰-invalid 류만 무효화. 410 은 무조건 무효화.
- notifyNewQuestion: dbNotifTasks Promise.all → pushTasks Promise.all 분리. badge 가 본인 알림을 정확히 셈.
- type-check 통과.

## Test plan
- [ ] BadCertificate / BadTopic 모의 응답 시 토큰 보존
- [ ] BadDeviceToken / Unregistered 시 토큰 정리
- [ ] 새 질문 발급 → 멤버들 푸시 badge 가 unread+1 (본인 NEW_QUESTION 포함)
- [ ] DB notifications 에 NEW_QUESTION 레코드 정상 저장

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)