### PR TITLE
fix(server): KST helper + DQ CAS + hearts guard (MG-45)

### DIFF
--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,15 +1,9 @@
 import { ScheduledEvent, Context } from 'aws-lambda';
 import prisma from './utils/prisma';
 import { QuestionService, notifyNewQuestion } from './services/QuestionService';
+import { getKstToday, isSameKstDate } from './utils/kst';
 
 const questionService = new QuestionService();
-
-// KST 기준 오늘 날짜를 UTC 자정으로 반환
-function getKstToday(): Date {
-  const now = new Date();
-  const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: 'Asia/Seoul' });
-  return new Date(kstDateStr + 'T00:00:00.000Z');
-}
 
 // 모든 가족에게 오늘의 질문 배정
 //
@@ -54,10 +48,13 @@ export async function assignDailyQuestions(): Promise<void> {
           ).map((a) => a.userId)
         );
 
+        // skippedDate 와 dq.date 는 둘 다 @db.Date 지만 timezone offset 에 따라
+        // getTime() 이 다르게 찍히는 케이스가 있어 (RDS 내부 normalization 차이),
+        // ISO 일자 문자열 비교로 통일. dailyQuestionCompletion / QuestionService 와 동일.
         const allCompleted = memberships.every(
           (m) =>
             answeredUserIds.has(m.userId) ||
-            (m.skippedDate !== null && m.skippedDate.getTime() === latestDQ.date.getTime())
+            isSameKstDate(m.skippedDate, latestDQ.date)
         );
 
         if (!allCompleted) {

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -317,7 +317,21 @@ export class AnswerService {
       throw Errors.forbidden('본인의 답변만 수정할 수 있습니다.');
     }
 
-    // 답변 수정 + 하트 차감 + colorId 업데이트를 원자적으로 처리
+    // 하트 잔액 사전 검사 — decrement 무조건 실행 시 음수 가능. 정책상 0 이하는 차단.
+    // 가족 소속 X 인 경우 하트 정책 자체를 적용 안 함.
+    if (user.familyId) {
+      const membership = await prisma.familyMembership.findUnique({
+        where: { userId_familyId: { userId: user.id, familyId: user.familyId } },
+        select: { hearts: true },
+      });
+      if (!membership || membership.hearts < 1) {
+        throw Errors.badRequest('하트가 부족합니다. 답변 수정에는 하트 1개가 필요합니다.');
+      }
+    }
+
+    // 답변 수정 + 하트 차감 + colorId 업데이트를 원자적으로 처리.
+    // hearts >= 1 조건을 updateMany where 에 명시해 위 사전 검사와 트랜잭션 사이의
+    // race (동시 다른 클라가 차감) 도 차단. count 0 이면 부족 에러로 환원.
     const updateOps: any[] = [
       prisma.answer.update({
         where: { id: normalizedAnswerId },
@@ -330,11 +344,14 @@ export class AnswerService {
       }),
     ];
 
-    // 하트 1개 차감 (가족 소속인 경우)
     if (user.familyId) {
       updateOps.push(
         prisma.familyMembership.updateMany({
-          where: { userId: user.id, familyId: user.familyId },
+          where: {
+            userId: user.id,
+            familyId: user.familyId,
+            hearts: { gte: 1 },
+          },
           data: {
             hearts: { decrement: 1 },
             ...(data.moodId && { colorId: data.moodId }),
@@ -343,7 +360,14 @@ export class AnswerService {
       );
     }
 
-    const [updated] = await prisma.$transaction(updateOps);
+    const result = await prisma.$transaction(updateOps);
+    const updated = result[0];
+    if (user.familyId) {
+      const heartsResult = result[1] as { count: number };
+      if (heartsResult.count === 0) {
+        throw Errors.badRequest('하트가 부족합니다. 답변 수정에는 하트 1개가 필요합니다.');
+      }
+    }
 
     return this.toAnswerResponse(updated);
   }

--- a/src/services/MoodService.ts
+++ b/src/services/MoodService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { toKstMidnight, getKstToday } from '../utils/kst';
 
 const prisma = new PrismaClient();
 
@@ -16,9 +17,9 @@ export interface SaveMoodResult {
 export class MoodService {
 
   async saveMood(userId: string, mood: string, note?: string, dateStr?: string): Promise<SaveMoodResult> {
-    const date = dateStr ? new Date(dateStr) : new Date();
-    // Normalize to date-only (midnight UTC)
-    const normalizedDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    // 클라이언트가 "오늘" 의도로 보낸 요청을 서버 UTC 기준으로 normalize 하면
+    // KST 0~8 시 요청이 전날로 저장되던 off-by-one 발생. KST 자정으로 통일.
+    const normalizedDate = dateStr ? toKstMidnight(dateStr) : getKstToday();
 
     const record = await prisma.moodRecord.upsert({
       where: { userId_date: { userId, date: normalizedDate } },
@@ -32,9 +33,9 @@ export class MoodService {
   }
 
   async getMoods(userId: string, days: number): Promise<MoodRecordDTO[]> {
-    const since = new Date();
-    since.setDate(since.getDate() - days);
-    const sinceNorm = new Date(Date.UTC(since.getFullYear(), since.getMonth(), since.getDate()));
+    const today = getKstToday();
+    const sinceNorm = new Date(today);
+    sinceNorm.setUTCDate(today.getUTCDate() - days);
 
     const records = await prisma.moodRecord.findMany({
       where: { userId, date: { gte: sinceNorm } },

--- a/src/services/dailyQuestionCompletion.ts
+++ b/src/services/dailyQuestionCompletion.ts
@@ -1,9 +1,5 @@
 import prisma from '../utils/prisma';
-
-function isSameDate(a: Date | null | undefined, b: Date | null | undefined): boolean {
-  if (!a || !b) return false;
-  return a.toISOString().split('T')[0] === b.toISOString().split('T')[0];
-}
+import { isSameKstDate } from '../utils/kst';
 
 /**
  * 해당 DailyQuestion이 "그룹 전원이 답변 또는 패스 완료" 상태인지 확인하고
@@ -48,17 +44,22 @@ export async function tryFinalizeDailyQuestion(params: {
   const answeredUserIds = new Set(answers.map((a) => a.userId));
 
   const allCompleted = memberships.every(
-    (m) => answeredUserIds.has(m.userId) || isSameDate(m.skippedDate, dq.date)
+    (m) => answeredUserIds.has(m.userId) || isSameKstDate(m.skippedDate, dq.date)
   );
   if (!allCompleted) return;
 
+  // CAS: completedAt: null 조건으로만 업데이트. 동시 호출 두 번 들어와도 한 번만
+  // 갱신되어 history 노출일이 흔들리지 않는다 (이전엔 update 가 무조건 덮어써 두 번째
+  // 호출의 now 로 바뀔 수 있었음).
   const now = new Date();
-  await prisma.dailyQuestion.update({
-    where: { id: dq.id },
+  const result = await prisma.dailyQuestion.updateMany({
+    where: { id: dq.id, completedAt: null },
     data: { completedAt: now },
   });
 
-  console.log(
-    `[DQ Finalize] family=${familyId} dq=${dq.id} assigned=${dq.date.toISOString().split('T')[0]} completedAt=${now.toISOString()}`
-  );
+  if (result.count === 1) {
+    console.log(
+      `[DQ Finalize] family=${familyId} dq=${dq.id} assigned=${dq.date.toISOString().split('T')[0]} completedAt=${now.toISOString()}`
+    );
+  }
 }

--- a/src/utils/kst.ts
+++ b/src/utils/kst.ts
@@ -1,0 +1,46 @@
+/**
+ * KST (UTC+9) 공통 날짜 헬퍼.
+ *
+ * Mongle 도메인은 "오늘"을 항상 KST 기준으로 본다. Lambda/RDS 가 UTC 인 환경에서
+ * `new Date()` 의 getFullYear/getMonth 등을 그대로 쓰면 KST 0~8 시 사이 요청이
+ * 하루 어긋나는 off-by-one 이 반복적으로 재발했다 (MoodService, scheduler 등).
+ * 모든 KST 날짜 처리는 이 모듈을 통해야 한다.
+ */
+
+const KST_TZ = 'Asia/Seoul';
+
+/**
+ * KST 기준 "오늘" 을 UTC 자정으로 표현한 Date.
+ * Prisma `@db.Date` 는 UTC 자정으로 저장되므로 비교/insert 에 안전.
+ */
+export function getKstToday(): Date {
+  const now = new Date();
+  const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: KST_TZ });
+  return new Date(kstDateStr + 'T00:00:00.000Z');
+}
+
+/**
+ * 임의 Date 를 KST "YYYY-MM-DD" 문자열로. 히스토리 노출일/UI key 용.
+ */
+export function toKstDateString(date: Date): string {
+  return date.toLocaleDateString('en-CA', { timeZone: KST_TZ });
+}
+
+/**
+ * KST 자정 정규화 — 문자열 또는 Date 입력을 받아 KST 자정 UTC 로 정규화.
+ * MoodService 처럼 클라이언트가 `dateStr` 또는 임의 시각을 보낼 때 사용.
+ */
+export function toKstMidnight(input: string | Date): Date {
+  const date = typeof input === 'string' ? new Date(input) : input;
+  const kstDateStr = date.toLocaleDateString('en-CA', { timeZone: KST_TZ });
+  return new Date(kstDateStr + 'T00:00:00.000Z');
+}
+
+/**
+ * 두 날짜가 같은 KST 일자인지. UTC 기준으로 비교하면 KST 0~8 시 가 전날로
+ * 잘못 묶이는 케이스가 있어 명시적 헬퍼 사용 권장.
+ */
+export function isSameKstDate(a: Date | null | undefined, b: Date | null | undefined): boolean {
+  if (!a || !b) return false;
+  return toKstDateString(a) === toKstDateString(b);
+}


### PR DESCRIPTION
## Jira
- [MG-45](https://ycompany.atlassian.net/browse/MG-45)

## Related
- 선행: MG-44 (Family race PR #37) — 머지 후 본 PR 적용 권장
- 1차 audit Question: MG-36 (history displayDate, 머지+배포 완료)

## Summary
- src/utils/kst.ts 신규 헬퍼 — Mood/scheduler/DQ finalize 통합
- MoodService UTC → KST normalize
- scheduler getTime() → isSameKstDate
- dailyQuestionCompletion CAS (updateMany + completedAt:null + count==1)
- AnswerService.updateAnswer hearts >= 1 가드 (사전 검사 + race 차단)
- type-check 통과

## Test plan
- [ ] KST 0~8 시 saveMood → 정확한 일자 저장
- [ ] 전날 carry-over 다음날 cron 적용
- [ ] DQ finalize 동시 2회 호출 → completedAt 1회 갱신
- [ ] hearts 0 사용자 updateAnswer → 400, hearts 그대로

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)