### PR TITLE
fix(server): quietHours + Nudge rate limit + REMINDER badge N+1 (MG-46)

### DIFF
--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -3,6 +3,7 @@ import prisma from './utils/prisma';
 import { NotificationService } from './services/NotificationService';
 import { PushNotificationService } from './services/PushNotificationService';
 import { getPushMessages } from './utils/i18n/push';
+import { isInQuietHours } from './utils/quietHours';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
@@ -83,6 +84,9 @@ export async function sendDailyReminders(): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
+          quietHoursEnabled: true,
+          quietHoursStart: true,
+          quietHoursEnd: true,
         },
       },
     },
@@ -189,26 +193,38 @@ export async function sendDailyReminders(): Promise<void> {
   }
   await Promise.all(dbNotifTasks);
 
+  // 배치 조회 ④: badge 카운트 N+1 제거. 푸시 대상 전체의 unread 를 한 번의 groupBy 로
+  // 조회 후 Map 으로 사용. 이전엔 user 마다 getUnreadCount 호출로 N 회 쿼리 발생.
+  const pushUserIds = Array.from(userInfoMap.keys());
+  const unreadCounts = await prisma.notification.groupBy({
+    by: ['userId'],
+    where: { userId: { in: pushUserIds }, isRead: false },
+    _count: { _all: true },
+  });
+  const unreadByUser = new Map<string, number>();
+  for (const row of unreadCounts) {
+    unreadByUser.set(row.userId, row._count._all);
+  }
+
   // 푸시 — 유저당 1회. 유저가 어느 가족에서든 미답변이면 미답변자 문구 사용(본인 답변이 더 긴급).
   const pushTasks: Promise<unknown>[] = [];
   for (const [userId, user] of userInfoMap) {
     if (!user.notifQuestion) continue;
+    if (isInQuietHours(user)) continue;
     const unanswered = userHasUnanswered.get(userId) ?? false;
     const { title, body } = makeBody(user.locale, unanswered);
+    const badgeCount = unreadByUser.get(userId) ?? 0;
 
     if (user.apnsToken) {
       pushTasks.push(
-        (async () => {
-          const badgeCount = await notificationService.getUnreadCount(userId);
-          await pushService.sendApnsPush(
-            user.apnsToken!,
-            title,
-            body,
-            'REMINDER',
-            badgeCount,
-            user.apnsEnvironment
-          );
-        })().catch((e) => {
+        pushService.sendApnsPush(
+          user.apnsToken!,
+          title,
+          body,
+          'REMINDER',
+          badgeCount,
+          user.apnsEnvironment
+        ).catch((e) => {
           console.warn('[Reminder] APNs 푸시 실패:', e);
         })
       );

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -11,6 +11,7 @@ import { NotificationService } from './NotificationService';
 import { PushNotificationService } from './PushNotificationService';
 import { tryFinalizeDailyQuestion } from './dailyQuestionCompletion';
 import { getPushMessages } from '../utils/i18n/push';
+import { isInQuietHours } from '../utils/quietHours';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
@@ -102,7 +103,11 @@ export class AnswerService {
         where: { familyId: user.familyId, userId: { not: user.id } },
         select: {
           user: {
-            select: { id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true, locale: true, notifAnswer: true },
+            select: {
+              id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true,
+              locale: true, notifAnswer: true,
+              quietHoursEnabled: true, quietHoursStart: true, quietHoursEnd: true,
+            },
           },
         },
       });
@@ -129,6 +134,8 @@ export class AnswerService {
       const pushTasks: Promise<unknown>[] = [];
       for (const member of otherMembers) {
         if (!member.notifAnswer) continue;
+        // quiet hours 면 푸시만 건너뜀. DB 알림은 1단계에서 이미 저장됨.
+        if (isInQuietHours(member)) continue;
         const msgs = getPushMessages(member.locale);
         const title = msgs.memberAnswered.title(senderNickname);
         const body = msgs.memberAnswered.body;

--- a/src/services/NudgeService.ts
+++ b/src/services/NudgeService.ts
@@ -3,9 +3,15 @@ import { Errors } from '../middleware/errorHandler';
 import { NotificationService } from './NotificationService';
 import { PushNotificationService } from './PushNotificationService';
 import { getPushMessages } from '../utils/i18n/push';
+import { isInQuietHours } from '../utils/quietHours';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
+
+// 동일 (sender, target) 페어 24시간 내 최대 재촉 횟수.
+// 알림 폭주 방지 + 답변 완료자 재촉 차단을 위한 1차 가드.
+const NUDGE_DAILY_LIMIT_PER_TARGET = 3;
+const NUDGE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export class NudgeService {
   /**
@@ -44,6 +50,44 @@ export class NudgeService {
       throw Errors.badRequest('자기 자신에게 재촉할 수 없습니다.');
     }
 
+    // 24시간 rate limit — 동일 대상에게 본인이 보낸 NUDGE 가 N건 이상이면 거부.
+    // Notification 테이블에 sender 컬럼이 없어 이번 PR 범위에서는 target 단위 누적
+    // (모든 sender 합산)으로 보호. follow-up: sender_user_id 컬럼 추가 후 페어 단위.
+    const recentNudges = await prisma.notification.count({
+      where: {
+        userId: target.id,
+        type: 'ANSWER_REQUEST',
+        createdAt: { gte: new Date(Date.now() - NUDGE_WINDOW_MS) },
+      },
+    });
+    if (recentNudges >= NUDGE_DAILY_LIMIT_PER_TARGET) {
+      throw Errors.tooMany(
+        `해당 구성원은 24시간 내 ${NUDGE_DAILY_LIMIT_PER_TARGET}회 이상 재촉되어 더 보낼 수 없습니다.`
+      );
+    }
+
+    // 답변 완료자에게 재촉 차단 — 그룹의 활성 DQ 에 대해 target 이 이미 답변/스킵 했으면 거부.
+    // 현재 DQ 가 carry-over 정책에 따라 임의 배정일을 가질 수 있으므로 latest DQ 기준.
+    const activeDQ = await prisma.dailyQuestion.findFirst({
+      where: { familyId: sender.familyId },
+      orderBy: { date: 'desc' },
+      select: { id: true, questionId: true, date: true },
+    });
+    if (activeDQ) {
+      const targetAnswered = await prisma.answer.findFirst({
+        where: { userId: target.id, questionId: activeDQ.questionId },
+        select: { id: true },
+      });
+      const targetSkipped =
+        targetMembership.skippedDate != null &&
+        activeDQ.date != null &&
+        targetMembership.skippedDate.toISOString().split('T')[0] ===
+          activeDQ.date.toISOString().split('T')[0];
+      if (targetAnswered || targetSkipped) {
+        throw Errors.badRequest('이미 답변/패스한 구성원에게는 재촉할 수 없습니다.');
+      }
+    }
+
     // 하트 차감 (FamilyMembership 기준)
     await prisma.familyMembership.updateMany({
       where: { userId: sender.id, familyId: sender.familyId },
@@ -71,9 +115,9 @@ export class NudgeService {
     );
 
     // 푸시 발송 — Lambda 환경에서는 반드시 await 해야 함.
-    // 알림 선호도 체크: notifNudge가 꺼져있으면 푸시 발송 건너뜀 (DB 알림 기록은 유지)
+    // 알림 선호도 체크: notifNudge 꺼졌거나 quiet hours 면 푸시 발송 건너뜀 (DB 알림 기록은 유지)
     const pushTasks: Promise<void>[] = [];
-    if (target.notifNudge) {
+    if (target.notifNudge && !isInQuietHours(target)) {
       if (target.apnsToken) {
         pushTasks.push(
           (async () => {

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -13,6 +13,7 @@ import { tryFinalizeDailyQuestion } from './dailyQuestionCompletion';
 import { NotificationService } from './NotificationService';
 import { PushNotificationService } from './PushNotificationService';
 import { getPushMessages } from '../utils/i18n/push';
+import { isInQuietHours } from '../utils/quietHours';
 
 export class QuestionService {
   /**
@@ -663,6 +664,9 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
+          quietHoursEnabled: true,
+          quietHoursStart: true,
+          quietHoursEnd: true,
         },
       },
     },
@@ -688,6 +692,7 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
   const pushTasks: Promise<unknown>[] = [];
   for (const m of members) {
     if (!m.notifQuestion) continue;
+    if (isInQuietHours(m)) continue;
     const msgs = getPushMessages(m.locale);
     const title = msgs.newQuestion.title;
     const body = msgs.newQuestion.body;

--- a/src/utils/quietHours.ts
+++ b/src/utils/quietHours.ts
@@ -1,0 +1,54 @@
+/**
+ * 사용자별 quiet hours (방해 금지 시간) 검사. 모든 푸시 경로에서 호출되어
+ * 시간대 안이면 푸시를 건너뛴다. DB 알림은 그대로 저장하므로 사용자가 앱을 열면
+ * 알림 리스트에서 확인 가능.
+ *
+ * 정책:
+ *   - quietHoursEnabled=false 이면 항상 false (적용 안 함)
+ *   - "HH:mm" 형식의 start/end 를 KST 기준으로 비교
+ *   - end < start (예: 22:00 ~ 08:00) 면 자정을 가로지르는 윈도우로 해석
+ *   - end == start (동일 시각) 은 비활성으로 간주 (전체 시간 차단 방지)
+ */
+
+const KST_TZ = 'Asia/Seoul';
+
+function parseHHmmToMinutes(s: string): number | null {
+  const m = /^(\d{2}):(\d{2})$/.exec(s);
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+function nowKstMinutes(now: Date = new Date()): number {
+  const hhmm = now.toLocaleTimeString('en-GB', {
+    timeZone: KST_TZ,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const [hh, mm] = hhmm.split(':').map((s) => parseInt(s, 10));
+  return hh * 60 + mm;
+}
+
+export function isInQuietHours(
+  prefs: {
+    quietHoursEnabled: boolean;
+    quietHoursStart: string;
+    quietHoursEnd: string;
+  } | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!prefs || !prefs.quietHoursEnabled) return false;
+  const start = parseHHmmToMinutes(prefs.quietHoursStart);
+  const end = parseHHmmToMinutes(prefs.quietHoursEnd);
+  if (start == null || end == null) return false;
+  if (start === end) return false;
+
+  const t = nowKstMinutes(now);
+  if (start < end) {
+    return t >= start && t < end;
+  }
+  return t >= start || t < end;
+}


### PR DESCRIPTION
## Jira
- [MG-46](https://ycompany.atlassian.net/browse/MG-46)

## Related
- 선행: MG-44/45 (Family/KST race) — 머지 후 적용 권장
- 1차 audit Push: MG-22 (APNs env), MG-23 (NEW_QUESTION 일관성)

## Summary
- quietHours.ts 신규 헬퍼
- 모든 푸시 경로 (MEMBER_ANSWERED/NEW_QUESTION/ANSWER_REQUEST/REMINDER) quietHours 가드
- NudgeService 24h 3회 제한 + 활성 DQ 답변/스킵자 차단
- REMINDER push badge: notification.groupBy 일괄 조회 (N+1 → 1)
- type-check 통과

## Test plan
- [ ] quietHours 활성 시 푸시 무발송, DB 알림은 저장 (앱 진입 시 표시)
- [ ] Nudge 24h 4회째 → 429
- [ ] 답변/스킵자에게 Nudge → 400
- [ ] 50명 대상 REMINDER → notification.groupBy 1회만 호출 (CloudWatch 로그)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)