### PR TITLE
feat(server): cleanup Lambda + leaveFamily notification orphan (MG-52)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -152,6 +152,18 @@ functions:
           rate: cron(0 10 * * ? *)
           enabled: ${self:custom.schedulerEnabled.${self:provider.stage}, false}
 
+  # 매일 새벽 만료/소비 row 정리 cron (KST 04:00 = UTC 19:00)
+  # EmailVerification / UserAccessLog / UserRefreshToken / Notification 일괄 정리.
+  # MG-52 — 무한 누적 차단 + LOGIN_LOCK piggyback 정리.
+  # enabled: MG-30 — prod 에서만 활성화 (dev 는 .env 가 prod DB 라 중복 실행 방지).
+  cleanupScheduler:
+    handler: src/cleanupScheduler.handler
+    timeout: 60
+    events:
+      - schedule:
+          rate: cron(0 19 * * ? *)
+          enabled: ${self:custom.schedulerEnabled.${self:provider.stage}, false}
+
 # 리소스 정의 (선택사항 - 별도 CloudFormation으로 관리 권장)
 # resources:
 #   Resources:

--- a/src/cleanupScheduler.ts
+++ b/src/cleanupScheduler.ts
@@ -1,0 +1,87 @@
+import { ScheduledEvent, Context } from 'aws-lambda';
+import prisma from './utils/prisma';
+
+/**
+ * 만료/소비된 row 와 무한 누적 가능 테이블을 일괄 정리하는 cron Lambda.
+ * KST 04:00 (UTC 19:00) 매일 실행. 보관 기간은 도메인 별로 다름:
+ *   - EmailVerification: 만료 또는 consumed=true 후 1일
+ *   - UserAccessLog: 90일
+ *   - UserRefreshToken: revokedAt 또는 expiresAt 후 30일
+ *   - Notification: 읽음 후 90일 / 미읽음 180일
+ *
+ * Lambda timeout 60초 안에서 deleteMany 단위로 처리 (chunk 안 걸어도 PostgreSQL 인덱스
+ * 지원 + 일배치라 충분). 한 도메인 실패해도 나머지는 진행하도록 try/catch 격리.
+ */
+export async function runCleanup(now: Date = new Date()): Promise<void> {
+  const oneDayAgo = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+  const oneEightyDaysAgo = new Date(now.getTime() - 180 * 24 * 60 * 60 * 1000);
+
+  const summary: Record<string, number> = {};
+
+  // 1) EmailVerification — 만료된 또는 consumed=true 후 1일 경과
+  try {
+    const r = await prisma.emailVerification.deleteMany({
+      where: {
+        OR: [
+          { consumed: true, createdAt: { lt: oneDayAgo } },
+          { expiresAt: { lt: oneDayAgo } },
+        ],
+      },
+    });
+    summary.emailVerification = r.count;
+  } catch (e) {
+    console.error('[Cleanup] EmailVerification 실패:', e);
+  }
+
+  // 2) UserAccessLog — 90일 이전
+  try {
+    const r = await prisma.userAccessLog.deleteMany({
+      where: { createdAt: { lt: ninetyDaysAgo } },
+    });
+    summary.userAccessLog = r.count;
+  } catch (e) {
+    console.error('[Cleanup] UserAccessLog 실패:', e);
+  }
+
+  // 3) UserRefreshToken — revokedAt 또는 만료 후 30일
+  try {
+    const r = await prisma.userRefreshToken.deleteMany({
+      where: {
+        OR: [
+          { revokedAt: { lt: thirtyDaysAgo } },
+          { expiresAt: { lt: thirtyDaysAgo } },
+        ],
+      },
+    });
+    summary.userRefreshToken = r.count;
+  } catch (e) {
+    console.error('[Cleanup] UserRefreshToken 실패:', e);
+  }
+
+  // 4) Notification — 읽음 90일 / 미읽음 180일
+  try {
+    const rRead = await prisma.notification.deleteMany({
+      where: { isRead: true, createdAt: { lt: ninetyDaysAgo } },
+    });
+    const rUnread = await prisma.notification.deleteMany({
+      where: { isRead: false, createdAt: { lt: oneEightyDaysAgo } },
+    });
+    summary.notificationRead = rRead.count;
+    summary.notificationUnread = rUnread.count;
+  } catch (e) {
+    console.error('[Cleanup] Notification 실패:', e);
+  }
+
+  console.log('[Cleanup] 일괄 정리 완료:', summary);
+}
+
+export const handler = async (_event: ScheduledEvent, _context: Context): Promise<void> => {
+  try {
+    await runCleanup();
+  } catch (err) {
+    console.error('[Cleanup] Lambda 실패:', err);
+    throw err;
+  }
+};

--- a/src/services/FamilyService.ts
+++ b/src/services/FamilyService.ts
@@ -387,8 +387,14 @@ export class FamilyService {
         throw Errors.forbidden('그룹 생성자는 그룹을 떠날 수 없습니다.');
       }
 
-      // 혼자인 경우: 가족 자체를 삭제
+      // 혼자인 경우: 가족 자체를 삭제. Notification.familyId 도 함께 nullify 해
+      // 클라이언트가 사라진 가족을 라우팅 대상으로 잡지 않게 한다 (FK 없는 nullable
+      // 컬럼이라 cascade 자동 처리 안 됨 — MG-52).
       await prisma.$transaction(async (tx) => {
+        await tx.notification.updateMany({
+          where: { familyId: targetFamilyId },
+          data: { familyId: null },
+        });
         await tx.familyMembership.deleteMany({ where: { familyId: targetFamilyId } });
         await tx.dailyQuestion.deleteMany({ where: { familyId: targetFamilyId } });
         await tx.family.delete({ where: { id: targetFamilyId } });
@@ -422,8 +428,13 @@ export class FamilyService {
       // 마지막 멤버 탈퇴 시 Family + DailyQuestion 정리. 정상 흐름에서는 creator 단독
       // 케이스가 위 분기에서 이미 처리되지만, transferCreator/race 시퀀스로 leave 가
       // 비-creator 경로를 타고도 멤버 0명이 될 수 있어 여기서 한 번 더 정리.
+      // Notification.familyId 도 nullify 해 사라진 가족 라우팅 방지 (MG-52).
       const remaining = await tx.familyMembership.count({ where: { familyId: targetFamilyId } });
       if (remaining === 0) {
+        await tx.notification.updateMany({
+          where: { familyId: targetFamilyId },
+          data: { familyId: null },
+        });
         await tx.dailyQuestion.deleteMany({ where: { familyId: targetFamilyId } });
         await tx.family.delete({ where: { id: targetFamilyId } });
       }


### PR DESCRIPTION
## Jira
- [MG-52](https://ycompany.atlassian.net/browse/MG-52)

## Related
- 선행: MG-42 (UserRefreshToken), MG-43 (LOGIN_LOCK piggyback) — 새 row 누적 원인
- 1차 audit Server: PR #25 (MG-30 schedulerEnabled stage 분리 패턴 재활용)
- audit2 잔여 backlog 의 cleanup 항목 통합

## Summary
- src/cleanupScheduler.ts 신규 + EventBridge cron 04:00 KST
- 4 테이블 보관 기간 정책 적용 (EV 1d / UAL 90d / URT 30d / Notification 90d-180d)
- leaveFamily 2 곳에 Notification.familyId nullify
- type-check 통과

## Deploy
1. main 머지
2. `npx serverless deploy --stage prod` (Lambda + EventBridge rule 신규 등록)
3. 익일 새벽 CloudWatch 로그 검증

## Test plan
- [ ] CloudWatch 익일 04:00 KST 로그 [Cleanup] 카운트 확인
- [ ] user_access_logs row count 감소 확인
- [ ] LOGIN_LOCK 만료된 row 정리
- [ ] leaveFamily 후 notifications.familyId nullify

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)