### PR TITLE
feat(notification): GET /notifications/unread-count (MG-54)

### DIFF
--- a/src/controllers/NotificationController.ts
+++ b/src/controllers/NotificationController.ts
@@ -14,6 +14,10 @@ interface DeleteCountResponse {
   count: number;
 }
 
+interface UnreadCountResponse {
+  count: number;
+}
+
 @Route('notifications')
 @Tags('Notification')
 export class NotificationController extends Controller {
@@ -47,6 +51,18 @@ export class NotificationController extends Controller {
     @Path() notificationId: string
   ): Promise<NotificationDTO> {
     return this.notificationService.markAsRead(req.user.userId, notificationId);
+  }
+
+  /**
+   * 미읽음 알림 수. OS 배지 동기화용 — iOS getNotifications(limit:50) 캡과 무관하게 정확.
+   * @summary 미읽음 카운트
+   */
+  @Get('unread-count')
+  @Security('jwt')
+  @SuccessResponse(200, '성공')
+  public async getUnreadCount(@Request() req: AuthRequest): Promise<UnreadCountResponse> {
+    const count = await this.notificationService.getUnreadCountForAuthUser(req.user.userId);
+    return { count };
   }
 
   /**

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -78,9 +78,16 @@ export class NotificationService {
     await prisma.notification.create({ data: { userId, type, title, body, familyId: familyId ?? null, colorId: colorId ?? null } });
   }
 
-  /** 유저의 미읽음 알림 수 (뱃지 카운트용) */
+  /** 유저의 미읽음 알림 수 (뱃지 카운트용). userId 는 User.id (내부 UUID). 푸시 서비스용. */
   async getUnreadCount(userId: string): Promise<number> {
     return prisma.notification.count({ where: { userId, isRead: false } });
+  }
+
+  /** 인증된 사용자의 미읽음 알림 수. iOS 가 OS 배지 동기화 시 호출 (50건 캡 우회용). */
+  async getUnreadCountForAuthUser(authUserId: string): Promise<number> {
+    const user = await prisma.user.findUnique({ where: { userId: authUserId }, select: { id: true } });
+    if (!user) return 0;
+    return prisma.notification.count({ where: { userId: user.id, isRead: false } });
   }
 
   private toDTO(n: { id: string; userId: string; familyId: string | null; colorId?: string | null; type: NotificationType; title: string; body: string; isRead: boolean; createdAt: Date }): NotificationDTO {


### PR DESCRIPTION
## Jira: [MG-54](https://ycompany.atlassian.net/browse/MG-54)

iOS OS 배지 50건 캡 우회용. NotificationService.getUnreadCountForAuthUser + Controller @Get unread-count.

후속: MG-55 (iOS Background/Push 안정화) 에서 사용.

## Test plan
- [ ] GET /notifications/unread-count 200 + accurate count
- [ ] 비인증 401

Closes #46