### PR TITLE
fix(heart): recordAccess race 차단을 conditional updateMany 로 강화 (MG-76)

### DIFF
--- a/scripts/race-sim-record-access.ts
+++ b/scripts/race-sim-record-access.ts
@@ -1,0 +1,78 @@
+/**
+ * recordAccess race 시뮬레이션.
+ *
+ * Lambda 환경처럼 connection 이 분리된 다수 클라이언트를 만들어
+ * 동시에 같은 사용자의 recordAccess 를 호출. 핫픽스(MG-76)가
+ * 정상 동작하면 hearts 는 정확히 +1 만 증가한다.
+ *
+ * 사용법: npx ts-node scripts/race-sim-record-access.ts
+ */
+import { PrismaClient } from '@prisma/client';
+import { getKstToday } from '../src/utils/kst';
+
+const TARGET_EMAIL = 'mrdydgjs@naver.com';
+const CONCURRENCY = 10;
+
+async function recordAccessOnce(p: PrismaClient, userPk: string, familyId: string | null) {
+  const kstToday = getKstToday();
+  await p.userAccessLog.create({ data: { userId: userPk } }).catch(() => {});
+  await p.$transaction(async (tx) => {
+    const result = await tx.user.updateMany({
+      where: {
+        id: userPk,
+        OR: [
+          { lastHeartGrantedAt: null },
+          { lastHeartGrantedAt: { lt: kstToday } },
+        ],
+      },
+      data: { lastHeartGrantedAt: new Date() },
+    });
+    if (result.count > 0 && familyId) {
+      await tx.familyMembership.updateMany({
+        where: { userId: userPk, familyId },
+        data: { hearts: { increment: 1 } },
+      });
+    }
+  });
+}
+
+async function main() {
+  const probe = new PrismaClient();
+  const user = await probe.user.findFirst({ where: { email: TARGET_EMAIL } });
+  if (!user) throw new Error('user not found');
+  if (!user.familyId) throw new Error('activeFamilyId is null');
+  const userPk = user.id;
+  const familyId = user.familyId;
+
+  // 리셋
+  await probe.user.update({ where: { id: userPk }, data: { lastHeartGrantedAt: null } });
+  const before = await probe.familyMembership.findUnique({
+    where: { userId_familyId: { userId: userPk, familyId } },
+  });
+  console.log(`BEFORE: hearts=${before?.hearts}  lastHeartGrantedAt=null`);
+
+  // 분리된 PrismaClient N 개로 동시 호출
+  const clients = Array.from({ length: CONCURRENCY }, () => new PrismaClient());
+  const t0 = Date.now();
+  await Promise.all(clients.map((c) => recordAccessOnce(c, userPk, familyId)));
+  const elapsed = Date.now() - t0;
+
+  const after = await probe.familyMembership.findUnique({
+    where: { userId_familyId: { userId: userPk, familyId } },
+  });
+  const u = await probe.user.findUniqueOrThrow({ where: { id: userPk } });
+
+  const delta = (after?.hearts ?? 0) - (before?.hearts ?? 0);
+  console.log(`AFTER  ${CONCURRENCY} concurrent calls (${elapsed}ms): hearts=${after?.hearts}  delta=${delta}`);
+  console.log(`lastHeartGrantedAt=${u.lastHeartGrantedAt?.toISOString()}`);
+  console.log(delta === 1 ? 'PASS — race 차단 정상' : `FAIL — delta=${delta} (expected 1)`);
+
+  await Promise.all(clients.map((c) => c.$disconnect()));
+  await probe.$disconnect();
+  if (delta !== 1) process.exit(2);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -55,32 +55,44 @@ export class UserService {
         console.warn('[recordAccess] access log 실패', { userId, err: (err as Error)?.message });
       });
 
-    // 트랜잭션 + 내부 재조회로 race 차단:
-    // 동일 유저의 동시 호출 시 두 번째 트랜잭션도 갱신된 lastHeartGrantedAt 을 보고
-    // alreadyGrantedToday 판정이 일관되어 +2 지급을 막는다.
+    // race 차단의 핵심: SELECT 없이 updateMany WHERE 에 시간 조건을 박아
+    // atomic test-and-set 으로 처리한다.
+    //
+    // Postgres 의 UPDATE 는 row-lock 을 잡으면서 WHERE 를 재평가하므로,
+    // 여러 Lambda 인스턴스가 동시에 같은 row 를 갱신하려 해도 가장 먼저
+    // 커밋한 한 트랜잭션만 count=1 을 받는다. 이후 트랜잭션은 락이 풀린
+    // 시점의 lastHeartGrantedAt 이 이미 kstToday 이상이라 WHERE 가 false →
+    // count=0 → +0 으로 정확히 갈라진다.
+    //
+    // 이전 SELECT→UPDATE 패턴은 READ COMMITTED 격리에서 lost-update
+    // 인터리빙을 허용해 동시 N 호출 시 +N 까지 갈 수 있었음 (MG-76).
     await prisma.$transaction(async (tx) => {
-      const fresh = await tx.user.findUniqueOrThrow({ where: { id: user.id } });
-      const alreadyGrantedToday =
-        fresh.lastHeartGrantedAt != null && fresh.lastHeartGrantedAt >= kstToday;
+      const grantResult = await tx.user.updateMany({
+        where: {
+          id: user.id,
+          OR: [
+            { lastHeartGrantedAt: null },
+            { lastHeartGrantedAt: { lt: kstToday } },
+          ],
+        },
+        data: {
+          lastHeartGrantedAt: new Date(),
+          ...(resolvedLocale && user.locale !== resolvedLocale ? { locale: resolvedLocale } : {}),
+        },
+      });
 
-      if (!alreadyGrantedToday) {
-        await tx.user.update({
-          where: { id: fresh.id },
-          data: {
-            lastHeartGrantedAt: new Date(),
-            ...(resolvedLocale && fresh.locale !== resolvedLocale ? { locale: resolvedLocale } : {}),
-          },
-        });
-        if (fresh.familyId) {
+      if (grantResult.count > 0) {
+        // 우리가 오늘 첫 지급자.
+        if (user.familyId) {
           await tx.familyMembership.updateMany({
-            where: { userId: fresh.id, familyId: fresh.familyId },
+            where: { userId: user.id, familyId: user.familyId },
             data: { hearts: { increment: 1 } },
           });
         }
-      } else if (resolvedLocale && fresh.locale !== resolvedLocale) {
-        // 오늘 하트는 이미 지급됐지만 locale 이 바뀌었으면 그것만 반영
+      } else if (resolvedLocale && user.locale !== resolvedLocale) {
+        // 이미 지급됨. locale 만 동기화.
         await tx.user.update({
-          where: { id: fresh.id },
+          where: { id: user.id },
           data: { locale: resolvedLocale },
         });
       }


### PR DESCRIPTION
## Jira
- [MG-76](https://ycompany.atlassian.net/browse/MG-76)

## Related
- 선행 머지: [#49 MG-75](https://github.com/rrheon/Mongle-Server/pull/49) — KST 타임존 + 트랜잭션 (race 차단이 부족했음)

## Summary
- MG-75 의 `$transaction { findUniqueOrThrow → update }` 패턴은 READ COMMITTED 에서 lost-update 허용 → Lambda 분리 인스턴스 환경에서 동시 N 호출 시 hearts +N 사례 확인 (mrdydgjs 사례 +3)
- SELECT 없이 `tx.user.updateMany` WHERE 시간 조건으로 atomic test-and-set
- `result.count > 0` 일 때만 `familyMembership +1` → 정확히 한 TX 만 지급

## Test plan
- [x] `scripts/race-sim-record-access.ts` 분리 PrismaClient 10개 시뮬 → delta=1 PASS
- [ ] mrdydgjs 데이터 리셋 후 dev 앱 접속 → hearts +1 만 (사용자 e2e)
- [ ] 멱등성: 동일 KST 날짜 재호출 → +0

## 배포
1. 머지 후 `npm run deploy:dev`
2. mrdydgjs hearts/lastHeartGrantedAt 리셋 → 사용자 앱 접속 검증
3. 검증 통과 시 `npm run deploy:prod`

⚠️ **prod 배포는 이 PR 머지될 때까지 보류**. 현재 main 의 #49 만으론 race 차단이 부족.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)