### PR TITLE
fix(heart): 데일리 하트 그룹별 lastHeartGrantedAt 분리 + opt-in 플래그 (MG-80)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,11 @@ model FamilyMembership {
   colorId           String?   @default("loved") @map("color_id")
   nicknameChangedAt DateTime? @map("nickname_changed_at")
   skippedDate       DateTime? @map("skipped_date") @db.Date
+  // 그룹별 데일리 +1 지급 추적. User.lastHeartGrantedAt 의 글로벌 한계를
+  // 보완 — 같은 KST 날짜에 그룹 A→B 전환 시 두 그룹 모두 +1 받게 한다.
+  // atomic test-and-set: WHERE { lastHeartGrantedAt: null OR < kstToday } 으로
+  // 동시 호출에서도 정확히 1번만 갱신.
+  lastHeartGrantedAt DateTime? @map("last_heart_granted_at")
   family            Family    @relation(fields: [familyId], references: [id])
   user              User      @relation(fields: [userId], references: [id])
 

--- a/scripts/backfill-membership-heart-granted.ts
+++ b/scripts/backfill-membership-heart-granted.ts
@@ -1,0 +1,34 @@
+/**
+ * MG-80 backfill: copy User.last_heart_granted_at into the active membership row.
+ *
+ * Schema diff (prisma db push) 가 column 만 추가하므로, 마이그레이션 파일에 정의된
+ * UPDATE backfill 을 별도 스크립트로 1회 실행한다. 본 스크립트는 idempotent —
+ * 활성 가족 행 중 NULL 인 것만 채워넣고, 이미 값이 있는 행은 그대로 둔다.
+ *
+ * 사용: npx ts-node scripts/backfill-membership-heart-granted.ts
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const result = await prisma.$executeRaw`
+    UPDATE family_memberships fm
+    SET last_heart_granted_at = u.last_heart_granted_at
+    FROM users u
+    WHERE fm.user_id = u.id
+      AND fm.family_id = u.family_id
+      AND u.last_heart_granted_at IS NOT NULL
+      AND fm.last_heart_granted_at IS NULL
+  `;
+  console.log(`backfilled rows: ${result}`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/race-sim-record-access.ts
+++ b/scripts/race-sim-record-access.ts
@@ -1,9 +1,10 @@
 /**
- * recordAccess race 시뮬레이션.
+ * 데일리 하트 grant race 시뮬레이션.
  *
- * Lambda 환경처럼 connection 이 분리된 다수 클라이언트를 만들어
- * 동시에 같은 사용자의 recordAccess 를 호출. 핫픽스(MG-76)가
- * 정상 동작하면 hearts 는 정확히 +1 만 증가한다.
+ * MG-80 부터 grant 키가 (userId, familyId) 단위 FamilyMembership 으로 바뀌었다.
+ * Lambda 환경처럼 connection 이 분리된 다수 클라이언트를 만들어 동시에 같은
+ * 멤버십에 대해 grantDailyHeartIfNeeded 를 호출. atomic test-and-set 이 정상이면
+ * hearts 는 정확히 +1 만 증가한다.
  *
  * 사용법: npx ts-node scripts/race-sim-record-access.ts
  */
@@ -13,26 +14,26 @@ import { getKstToday } from '../src/utils/kst';
 const TARGET_EMAIL = 'mrdydgjs@naver.com';
 const CONCURRENCY = 10;
 
-async function recordAccessOnce(p: PrismaClient, userPk: string, familyId: string | null) {
+async function grantDailyHeartOnce(
+  p: PrismaClient,
+  userPk: string,
+  familyId: string
+) {
   const kstToday = getKstToday();
   await p.userAccessLog.create({ data: { userId: userPk } }).catch(() => {});
-  await p.$transaction(async (tx) => {
-    const result = await tx.user.updateMany({
-      where: {
-        id: userPk,
-        OR: [
-          { lastHeartGrantedAt: null },
-          { lastHeartGrantedAt: { lt: kstToday } },
-        ],
-      },
-      data: { lastHeartGrantedAt: new Date() },
-    });
-    if (result.count > 0 && familyId) {
-      await tx.familyMembership.updateMany({
-        where: { userId: userPk, familyId },
-        data: { hearts: { increment: 1 } },
-      });
-    }
+  await p.familyMembership.updateMany({
+    where: {
+      userId: userPk,
+      familyId,
+      OR: [
+        { lastHeartGrantedAt: null },
+        { lastHeartGrantedAt: { lt: kstToday } },
+      ],
+    },
+    data: {
+      lastHeartGrantedAt: new Date(),
+      hearts: { increment: 1 },
+    },
   });
 }
 
@@ -44,27 +45,30 @@ async function main() {
   const userPk = user.id;
   const familyId = user.familyId;
 
-  // 리셋
-  await probe.user.update({ where: { id: userPk }, data: { lastHeartGrantedAt: null } });
+  // 활성 멤버십 lastHeartGrantedAt 만 리셋 (다른 그룹은 그대로 둠)
+  await probe.familyMembership.updateMany({
+    where: { userId: userPk, familyId },
+    data: { lastHeartGrantedAt: null },
+  });
   const before = await probe.familyMembership.findUnique({
     where: { userId_familyId: { userId: userPk, familyId } },
   });
-  console.log(`BEFORE: hearts=${before?.hearts}  lastHeartGrantedAt=null`);
+  console.log(`BEFORE: hearts=${before?.hearts}  lastHeartGrantedAt=null (membership)`);
 
-  // 분리된 PrismaClient N 개로 동시 호출
   const clients = Array.from({ length: CONCURRENCY }, () => new PrismaClient());
   const t0 = Date.now();
-  await Promise.all(clients.map((c) => recordAccessOnce(c, userPk, familyId)));
+  await Promise.all(clients.map((c) => grantDailyHeartOnce(c, userPk, familyId)));
   const elapsed = Date.now() - t0;
 
   const after = await probe.familyMembership.findUnique({
     where: { userId_familyId: { userId: userPk, familyId } },
   });
-  const u = await probe.user.findUniqueOrThrow({ where: { id: userPk } });
 
   const delta = (after?.hearts ?? 0) - (before?.hearts ?? 0);
-  console.log(`AFTER  ${CONCURRENCY} concurrent calls (${elapsed}ms): hearts=${after?.hearts}  delta=${delta}`);
-  console.log(`lastHeartGrantedAt=${u.lastHeartGrantedAt?.toISOString()}`);
+  console.log(
+    `AFTER  ${CONCURRENCY} concurrent calls (${elapsed}ms): hearts=${after?.hearts}  delta=${delta}`
+  );
+  console.log(`membership.lastHeartGrantedAt=${after?.lastHeartGrantedAt?.toISOString()}`);
   console.log(delta === 1 ? 'PASS — race 차단 정상' : `FAIL — delta=${delta} (expected 1)`);
 
   await Promise.all(clients.map((c) => c.$disconnect()));

--- a/scripts/verify-mg80-group-switch.ts
+++ b/scripts/verify-mg80-group-switch.ts
@@ -1,0 +1,117 @@
+/**
+ * MG-80 e2e: 같은 KST 날짜 그룹 전환 시 양쪽 그룹 +1 검증.
+ *
+ * 시나리오:
+ *  1) mrdydgjs 의 활성 그룹 A 와 임의 비활성 그룹 B 의 lastHeartGrantedAt 을 null 로 리셋
+ *  2) A 에서 grantDailyHeartIfNeeded → A.hearts +=1, A.lastHeartGrantedAt 채워짐
+ *  3) 같은 KST 안에 B 로 활성 전환 후 grantDailyHeartIfNeeded → B.hearts +=1, B.lastHeartGrantedAt
+ *     채워짐, A 영향 없음 (이전엔 +0 누락)
+ *  4) A 로 다시 전환 후 grantDailyHeartIfNeeded → 변동 없음 (A 는 이미 today)
+ *
+ * 본 스크립트는 read-only API 호출이 아니라 서비스 메서드를 직접 호출하므로
+ * 활성 가족 전환은 user.familyId 업데이트로만 시뮬레이트한다 (실제 그룹 선택 API
+ * 의 다른 부수효과는 본 검증 범위 밖).
+ */
+import { PrismaClient } from '@prisma/client';
+import { UserService } from '../src/services/UserService';
+
+const TARGET_EMAIL = 'mrdydgjs@naver.com';
+const prisma = new PrismaClient();
+const service = new UserService();
+
+async function snapshot(userPk: string, label: string) {
+  const memberships = await prisma.familyMembership.findMany({
+    where: { userId: userPk },
+    include: { family: { select: { name: true } } },
+  });
+  console.log(`\n--- ${label} ---`);
+  for (const m of memberships) {
+    console.log(
+      `  ${m.family.name.padEnd(8)}  hearts=${String(m.hearts).padStart(2)}  ` +
+        `granted=${m.lastHeartGrantedAt?.toISOString() ?? 'null'}`
+    );
+  }
+  return memberships;
+}
+
+async function main() {
+  const user = await prisma.user.findFirst({ where: { email: TARGET_EMAIL } });
+  if (!user) throw new Error('user not found');
+  const userPk = user.id;
+  const originalActiveFamilyId = user.familyId;
+
+  // 그룹 두 개 선택 (활성 = test, 비활성 첫 번째 = zxx 또는 ㅋㅋㅋ)
+  const memberships = await prisma.familyMembership.findMany({
+    where: { userId: userPk },
+    select: { familyId: true, family: { select: { name: true } } },
+  });
+  const familyA = memberships.find((m) => m.familyId === originalActiveFamilyId);
+  const familyB = memberships.find((m) => m.familyId !== originalActiveFamilyId);
+  if (!familyA || !familyB) throw new Error('memberships < 2');
+
+  console.log(`A=${familyA.family.name} (active), B=${familyB.family.name}`);
+
+  // 1) 두 멤버십 모두 lastHeartGrantedAt 리셋
+  await prisma.familyMembership.updateMany({
+    where: { userId: userPk, familyId: { in: [familyA.familyId, familyB.familyId] } },
+    data: { lastHeartGrantedAt: null },
+  });
+  await snapshot(userPk, 'after reset');
+
+  // 2) A 활성 상태에서 getUserByUserId({ grantDailyHeart: true })
+  const respA = await service.getUserByUserId(user.userId, { grantDailyHeart: true });
+  console.log(
+    `\n[step 2] A grant → heartGrantedToday=${respA.heartGrantedToday}, hearts=${respA.hearts}`
+  );
+  await snapshot(userPk, 'after A grant');
+
+  // 3) B 로 활성 전환 (familyId 만 변경) 후 grant
+  await prisma.user.update({ where: { id: userPk }, data: { familyId: familyB.familyId } });
+  const respB = await service.getUserByUserId(user.userId, { grantDailyHeart: true });
+  console.log(
+    `\n[step 3] B grant → heartGrantedToday=${respB.heartGrantedToday}, hearts=${respB.hearts}`
+  );
+  await snapshot(userPk, 'after B grant');
+
+  // 4) A 로 다시 전환 후 grant — 변동 없어야 함
+  await prisma.user.update({ where: { id: userPk }, data: { familyId: familyA.familyId } });
+  const respA2 = await service.getUserByUserId(user.userId, { grantDailyHeart: true });
+  console.log(
+    `\n[step 4] A re-grant → heartGrantedToday=${respA2.heartGrantedToday}, hearts=${respA2.hearts}`
+  );
+  await snapshot(userPk, 'after A re-grant');
+
+  // 5) opt-in 미포함 호출 → grant 미발동
+  const respNoOpt = await service.getUserByUserId(user.userId);
+  console.log(
+    `\n[step 5] no opt-in → heartGrantedToday=${respNoOpt.heartGrantedToday}, hearts=${respNoOpt.hearts}`
+  );
+
+  // 원상복구: 활성 그룹을 원래로
+  if (originalActiveFamilyId) {
+    await prisma.user.update({
+      where: { id: userPk },
+      data: { familyId: originalActiveFamilyId },
+    });
+  }
+
+  // 검증
+  const pass2 = respA.heartGrantedToday === true;
+  const pass3 = respB.heartGrantedToday === true;
+  const pass4 = respA2.heartGrantedToday === false;
+  const pass5 = respNoOpt.heartGrantedToday === false;
+  console.log(
+    `\nresult: step2=${pass2 ? 'PASS' : 'FAIL'}, step3=${pass3 ? 'PASS' : 'FAIL'}, ` +
+      `step4=${pass4 ? 'PASS' : 'FAIL'}, step5=${pass5 ? 'PASS' : 'FAIL'}`
+  );
+  if (!(pass2 && pass3 && pass4 && pass5)) process.exit(2);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -7,6 +7,7 @@ import {
   Route,
   Body,
   Path,
+  Query,
   Security,
   Request,
   Tags,
@@ -23,13 +24,24 @@ export class UserController extends Controller {
 
   /**
    * 현재 로그인한 사용자 정보 조회
+   *
+   * grantDailyHeart=true 인 호출은 활성 그룹 데일리 하트(+1) 지급을 동기적으로
+   * 시도하고 응답의 heartGrantedToday 에 결과를 실어 보낸다. iOS 의 onAppear /
+   * refreshHomeData 에서만 켜고, QuestionDetail 같은 부수 hearts sync 호출은
+   * 기본값(false)으로 호출해 거짓 grant 를 방지한다 (MG-80, MG-77).
+   *
    * @summary 내 정보 조회
    */
   @Get('me')
   @Security('jwt')
   @SuccessResponse(200, '성공')
-  public async getMe(@Request() req: AuthRequest): Promise<UserResponse> {
-    return this.userService.getUserByUserId(req.user.userId);
+  public async getMe(
+    @Request() req: AuthRequest,
+    @Query() grantDailyHeart?: boolean
+  ): Promise<UserResponse> {
+    return this.userService.getUserByUserId(req.user.userId, {
+      grantDailyHeart: grantDailyHeart === true,
+    });
   }
 
   /**

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -65,12 +65,14 @@ export async function expressAuthentication(
   const [bearer, token] = authHeader.split(' ');
   if (bearer !== 'Bearer' || !token) throw new Error('Invalid authorization header format');
 
-  // 매 요청의 Accept-Language 를 user.locale 로 동기화 → 푸시 다국어 문구 선택에 사용
+  // 매 요청의 Accept-Language 를 user.locale 로 동기화 → 푸시 다국어 문구 선택에 사용.
+  // 데일리 하트 +1 지급은 /users/me?grantDailyHeart=true 동기 경로로 분리됐으므로(MG-80)
+  // 여기선 access log + locale 동기화만 fire-and-forget 으로 수행한다.
   const acceptLanguage = request.headers['accept-language'] as string | undefined;
-  const recordAccessSilently = (userId: string) => {
+  const logAccessSilently = (userId: string) => {
     import('../services/UserService').then(({ UserService }) => {
-      new UserService().recordAccess(userId, acceptLanguage).catch((err) => {
-        console.warn('[Auth] recordAccess failed', { userId, err: (err as Error)?.message });
+      new UserService().logAccess(userId, acceptLanguage).catch((err) => {
+        console.warn('[Auth] logAccess failed', { userId, err: (err as Error)?.message });
       });
     });
   };
@@ -79,7 +81,7 @@ export async function expressAuthentication(
   try {
     const { verifyCustomToken } = await import('../utils/jwt');
     const payload = verifyCustomToken(token);
-    recordAccessSilently(payload.sub);
+    logAccessSilently(payload.sub);
     return { userId: payload.sub, email: payload.email };
   } catch {
     // 커스텀 JWT 아님, Cognito 토큰 시도
@@ -87,7 +89,7 @@ export async function expressAuthentication(
 
   try {
     const payload = await verifyToken(token);
-    recordAccessSilently(payload.sub);
+    logAccessSilently(payload.sub);
     return { userId: payload.sub, email: payload.email };
   } catch {
     throw new Error('Invalid or expired token');

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,6 +17,12 @@ export interface UserResponse {
   hearts: number;
   moodId: string | null;
   createdAt: Date;
+  /**
+   * /users/me?grantDailyHeart=true 호출 시점에 활성 그룹 데일리 하트 +1 이
+   * 이번 요청에서 발생했는지 여부. opt-in 이 아닌 호출에서는 항상 false.
+   * iOS 는 이 플래그로만 데일리 하트 팝업을 트리거한다 (MG-77).
+   */
+  heartGrantedToday: boolean;
 }
 
 export interface UpdateUserRequest {

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -453,6 +453,7 @@ export class AnswerService {
         hearts: answer.user.hearts,
         moodId: resolvedMoodId,
         createdAt: answer.user.createdAt,
+        heartGrantedToday: false,
       },
     };
   }

--- a/src/services/FamilyService.ts
+++ b/src/services/FamilyService.ts
@@ -641,6 +641,7 @@ export class FamilyService {
       hearts: membership.hearts, // 그룹별 하트
       moodId: membership.colorId ?? membership.user.moodId ?? null, // 그룹별 색상 우선
       createdAt: membership.user.createdAt,
+      heartGrantedToday: false,
     };
   }
 
@@ -665,6 +666,7 @@ export class FamilyService {
       hearts: user.hearts,
       moodId: user.moodId ?? null,
       createdAt: user.createdAt,
+      heartGrantedToday: false,
     };
   }
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -9,10 +9,26 @@ const MAX_AD_HEARTS = 5; // 1회 광고 시청 보상 최대 하트 수
 export class UserService {
   /**
    * userId로 사용자 조회 (현재 활성 가족의 그룹별 nickname, hearts, role 반환)
+   *
+   * options.grantDailyHeart=true 인 호출은 그룹별 데일리 하트(+1) 지급을
+   * 동기적으로 시도하고, 결과를 응답의 heartGrantedToday / hearts 에 반영한다.
+   * iOS 의 명시적 opt-in 경로(refreshHomeData / onAppear)에서만 켜고, 부수
+   * 호출(QuestionDetail/ProfileEdit hearts sync 등)은 default false 로 호출해
+   * "오늘 첫 호출이 부수 경로에서 발생해 grant 만 되고 팝업은 누락" 되는
+   * 시나리오를 막는다.
    */
-  async getUserByUserId(userId: string): Promise<UserResponse> {
+  async getUserByUserId(
+    userId: string,
+    options?: { grantDailyHeart?: boolean }
+  ): Promise<UserResponse> {
     const user = await prisma.user.findUnique({ where: { userId } });
     if (!user) throw Errors.notFound('사용자');
+
+    let heartGrantedToday = false;
+    if (options?.grantDailyHeart && user.familyId) {
+      const result = await this.grantDailyHeartIfNeeded(user.id, user.familyId);
+      heartGrantedToday = result.granted;
+    }
 
     if (user.familyId) {
       const membership = await prisma.familyMembership.findUnique({
@@ -29,74 +45,74 @@ export class UserService {
           hearts: membership.hearts,
           moodId: membership.colorId ?? user.moodId ?? null,
           createdAt: user.createdAt,
+          heartGrantedToday,
         };
       }
     }
 
-    return this.toUserResponse(user);
+    return { ...this.toUserResponse(user), heartGrantedToday };
   }
 
   /**
-   * 접속 기록 저장 + 하루 첫 접속 시 활성 가족 그룹 하트 +1
+   * 접속 로그 + locale 동기화. heart 지급은 분리됨(grantDailyHeartIfNeeded).
+   *
+   * 이전 recordAccess 가 한 번에 묶고 있던 access log + locale + heart 지급
+   * 셋 중 heart 지급만 떼어 /users/me?grantDailyHeart=true 동기 경로로 이전
+   * (MG-80). 응답 본문에 heartGrantedToday 플래그를 실어 iOS 가 거짓 팝업
+   * 가능성 없이 정합 트리거하도록 만들기 위함.
    */
-  async recordAccess(userId: string, acceptLanguage?: string | null): Promise<void> {
+  async logAccess(userId: string, acceptLanguage?: string | null): Promise<void> {
     const user = await prisma.user.findUnique({ where: { userId } });
     if (!user) return;
 
-    // KST 자정을 UTC 로 정규화 — Lambda 가 UTC 인 환경에서 KST 0~8시 요청이
-    // 전날로 잘못 묶이는 off-by-one 을 차단.
-    const kstToday = getKstToday();
-    const resolvedLocale = acceptLanguage ? resolveLocaleFromHeader(acceptLanguage) : null;
-
-    // 액세스 로그는 본 로직 영향 최소화를 위해 트랜잭션 밖에서 fire-and-forget
     prisma.userAccessLog
       .create({ data: { userId: user.id } })
       .catch((err) => {
-        console.warn('[recordAccess] access log 실패', { userId, err: (err as Error)?.message });
+        console.warn('[logAccess] access log 실패', { userId, err: (err as Error)?.message });
       });
 
-    // race 차단의 핵심: SELECT 없이 updateMany WHERE 에 시간 조건을 박아
-    // atomic test-and-set 으로 처리한다.
-    //
-    // Postgres 의 UPDATE 는 row-lock 을 잡으면서 WHERE 를 재평가하므로,
-    // 여러 Lambda 인스턴스가 동시에 같은 row 를 갱신하려 해도 가장 먼저
-    // 커밋한 한 트랜잭션만 count=1 을 받는다. 이후 트랜잭션은 락이 풀린
-    // 시점의 lastHeartGrantedAt 이 이미 kstToday 이상이라 WHERE 가 false →
-    // count=0 → +0 으로 정확히 갈라진다.
-    //
-    // 이전 SELECT→UPDATE 패턴은 READ COMMITTED 격리에서 lost-update
-    // 인터리빙을 허용해 동시 N 호출 시 +N 까지 갈 수 있었음 (MG-76).
-    await prisma.$transaction(async (tx) => {
-      const grantResult = await tx.user.updateMany({
-        where: {
-          id: user.id,
-          OR: [
-            { lastHeartGrantedAt: null },
-            { lastHeartGrantedAt: { lt: kstToday } },
-          ],
-        },
-        data: {
-          lastHeartGrantedAt: new Date(),
-          ...(resolvedLocale && user.locale !== resolvedLocale ? { locale: resolvedLocale } : {}),
-        },
-      });
-
-      if (grantResult.count > 0) {
-        // 우리가 오늘 첫 지급자.
-        if (user.familyId) {
-          await tx.familyMembership.updateMany({
-            where: { userId: user.id, familyId: user.familyId },
-            data: { hearts: { increment: 1 } },
-          });
-        }
-      } else if (resolvedLocale && user.locale !== resolvedLocale) {
-        // 이미 지급됨. locale 만 동기화.
-        await tx.user.update({
-          where: { id: user.id },
-          data: { locale: resolvedLocale },
+    const resolvedLocale = acceptLanguage ? resolveLocaleFromHeader(acceptLanguage) : null;
+    if (resolvedLocale && user.locale !== resolvedLocale) {
+      await prisma.user
+        .update({ where: { id: user.id }, data: { locale: resolvedLocale } })
+        .catch((err) => {
+          console.warn('[logAccess] locale 동기화 실패', { userId, err: (err as Error)?.message });
         });
-      }
+    }
+  }
+
+  /**
+   * 활성 그룹 데일리 하트 +1 (atomic test-and-set on FamilyMembership).
+   *
+   * race 차단 패턴은 MG-76 과 동일: SELECT 없이 updateMany WHERE 에 시간
+   * 조건을 박아 가장 먼저 커밋한 트랜잭션만 count=1 을 받게 한다. 이전
+   * 글로벌 User.lastHeartGrantedAt 기준이었을 땐 같은 KST 날짜에 그룹
+   * A→B 전환 시 새 그룹이 +0 으로 누락되는 결함이 있었음 (MG-80 design flaw).
+   * 이제 (userId, familyId) 키로 처리하므로 그룹별 매일 1개가 자연스럽게 보장.
+   *
+   * hearts increment 도 같은 updateMany 안에 포함해 grant 와 +1 이 한
+   * 트랜잭션·한 row 단위로 묶이게 한다 (분리하면 락 해제 사이 인터리빙 가능).
+   */
+  async grantDailyHeartIfNeeded(
+    userPk: string,
+    familyId: string
+  ): Promise<{ granted: boolean }> {
+    const kstToday = getKstToday();
+    const result = await prisma.familyMembership.updateMany({
+      where: {
+        userId: userPk,
+        familyId,
+        OR: [
+          { lastHeartGrantedAt: null },
+          { lastHeartGrantedAt: { lt: kstToday } },
+        ],
+      },
+      data: {
+        lastHeartGrantedAt: new Date(),
+        hearts: { increment: 1 },
+      },
     });
+    return { granted: result.count > 0 };
   }
 
   /**
@@ -359,6 +375,7 @@ export class UserService {
       hearts: user.hearts,
       moodId: user.moodId ?? null,
       createdAt: user.createdAt,
+      heartGrantedToday: false,
     };
   }
 }


### PR DESCRIPTION
## Jira
- [MG-80](https://ycompany.atlassian.net/browse/MG-80)

## Related
- iOS 후속 PR: [MG-77](https://ycompany.atlassian.net/browse/MG-77) — 본 PR prod 배포 후 머지
- 보상 race 시리즈: MG-75 / MG-76 / MG-78

## Summary
- `FamilyMembership.lastHeartGrantedAt` 컬럼 추가 (db push + 활성 가족 한정 backfill). `User.lastHeartGrantedAt` 은 rollback 안전망으로 유지.
- `recordAccess` 분리 → `logAccess` (fire-and-forget) + `grantDailyHeartIfNeeded` (membership atomic test-and-set, MG-76 패턴 + hearts increment 동일 트랜잭션)
- `GET /users/me` 에 `grantDailyHeart` 쿼리 파라미터 추가 — 명시적 opt-in 만 grant 트리거. 부수 호출(QuestionDetail/ProfileEdit hearts sync)은 default false 로 영향 없음.
- `UserResponse.heartGrantedToday` 필드 추가 — iOS MG-77 PR 가 이 플래그로 팝업 트리거 (UserDefaults 카운터 제거)
- 미들웨어 `recordAccessSilently` → `logAccessSilently` 로 축소

## Test plan
- [x] `scripts/race-sim-record-access.ts` (membership 키, 분리 PrismaClient 10개 동시) → 정확히 +1
- [x] `scripts/verify-mg80-group-switch.ts` mrdydgjs e2e — step2/3/4/5 모두 PASS
  - step2 A grant → heartGrantedToday=true
  - step3 B 전환 후 grant → B +1, A 영향 없음 (이전엔 +0 누락)
  - step4 A 재호출 → false
  - step5 opt-in 미포함 → false
- [ ] `npm run deploy:dev` 후 curl 로 `/users/me?grantDailyHeart=true` 응답 확인
- [ ] `npm run deploy:prod`
- [ ] iOS MG-77 PR 빌드 → TestFlight 검증

## 호환성
- 구버전 iOS 는 `grantDailyHeart` 보내지 않음 → default false → 일시적으로 데일리 하트 미수령. MG-77 iOS PR 도 같은 사이클에 머지·빌드해 갭 최소화 필요.

## 후속
- `User.lastHeartGrantedAt` 컬럼 제거 (prod 안정화 N주 후 별도 티켓)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)