### PR TITLE
fix(heart): KST 0~9시 데일리 하트 매 호출 +1 결함 차단 (MG-81)

### DIFF
--- a/scripts/race-sim-record-access.ts
+++ b/scripts/race-sim-record-access.ts
@@ -9,17 +9,19 @@
  * 사용법: npx ts-node scripts/race-sim-record-access.ts
  */
 import { PrismaClient } from '@prisma/client';
-import { getKstToday } from '../src/utils/kst';
+import { getKstMidnightUtc } from '../src/utils/kst';
 
 const TARGET_EMAIL = 'mrdydgjs@naver.com';
 const CONCURRENCY = 10;
 
+// production 의 UserService.grantDailyHeartIfNeeded 와 같은 cutoff·WHERE 를
+// inline 으로 복제. 단 cutoff 는 시각 포함 컬럼용 헬퍼 사용 (MG-81).
 async function grantDailyHeartOnce(
   p: PrismaClient,
   userPk: string,
   familyId: string
 ) {
-  const kstToday = getKstToday();
+  const cutoff = getKstMidnightUtc();
   await p.userAccessLog.create({ data: { userId: userPk } }).catch(() => {});
   await p.familyMembership.updateMany({
     where: {
@@ -27,7 +29,7 @@ async function grantDailyHeartOnce(
       familyId,
       OR: [
         { lastHeartGrantedAt: null },
-        { lastHeartGrantedAt: { lt: kstToday } },
+        { lastHeartGrantedAt: { lt: cutoff } },
       ],
     },
     data: {

--- a/scripts/verify-mg81-kst-window.ts
+++ b/scripts/verify-mg81-kst-window.ts
@@ -1,0 +1,88 @@
+/**
+ * MG-81 검증: KST 0~9시 윈도우에서 grantDailyHeartIfNeeded 가 idempotent 한지.
+ *
+ * 결함 재현: cutoff 가 getKstToday() (UTC 자정 표기) 였을 땐 KST 0~9시 사이
+ * 두 번째 호출도 lastHeartGrantedAt < cutoff 가 TRUE 가 되어 매번 +1 발생.
+ *
+ * 검증 흐름:
+ *   1) mrdydgjs / ㅋㅋㅋ 그룹 membership.lastHeartGrantedAt = null 로 reset
+ *   2) UserService.grantDailyHeartIfNeeded 를 5회 연속 호출
+ *   3) granted 결과는 [true, false, false, false, false] 여야 함
+ *   4) hearts 증가량은 정확히 +1 이어야 함
+ *
+ * KST 09시 이후 실행해도 PASS 하지만 의미 없음 (그 시간엔 버그 미발현).
+ * 가능하면 KST 00~09시 사이에 돌릴 것.
+ */
+import prisma from '../src/utils/prisma';
+import { UserService } from '../src/services/UserService';
+
+const TARGET_EMAIL = 'mrdydgjs@naver.com';
+const TARGET_FAMILY_NAME = 'ㅋㅋㅋ';
+const ITERATIONS = 5;
+
+async function main() {
+  const nowKst = new Date().toLocaleString('en-CA', { timeZone: 'Asia/Seoul' });
+  const kstHour = new Date().toLocaleString('en-US', {
+    timeZone: 'Asia/Seoul',
+    hour: 'numeric',
+    hour12: false,
+  });
+  console.log(`[verify-mg81] now KST = ${nowKst} (hour=${kstHour})`);
+  if (Number(kstHour) >= 9) {
+    console.warn('[verify-mg81] WARN: KST 09시 이후 — 결함이 발현되지 않는 시간대. PASS 해도 무의미.');
+  }
+
+  const user = await prisma.user.findFirst({ where: { email: TARGET_EMAIL } });
+  if (!user) throw new Error(`user not found: ${TARGET_EMAIL}`);
+
+  const memberships = await prisma.familyMembership.findMany({
+    where: { userId: user.id },
+    include: { family: { select: { name: true } } },
+  });
+  const target = memberships.find((m) => m.family.name === TARGET_FAMILY_NAME);
+  if (!target) throw new Error(`target family not found: ${TARGET_FAMILY_NAME}`);
+
+  const heartsBefore = target.hearts;
+  console.log(`[verify-mg81] target = ${TARGET_FAMILY_NAME} (familyId=${target.familyId})`);
+  console.log(`[verify-mg81] hearts before reset = ${heartsBefore}`);
+
+  // reset: 어제 grant 받은 상태로 되돌림 (사용자에게 영향 최소)
+  await prisma.familyMembership.update({
+    where: { userId_familyId: { userId: user.id, familyId: target.familyId } },
+    data: { lastHeartGrantedAt: null },
+  });
+  console.log(`[verify-mg81] lastHeartGrantedAt = null 로 reset 완료`);
+
+  const userService = new UserService();
+  const results: boolean[] = [];
+  for (let i = 0; i < ITERATIONS; i++) {
+    const r = await userService.grantDailyHeartIfNeeded(user.id, target.familyId);
+    results.push(r.granted);
+  }
+
+  const after = await prisma.familyMembership.findUnique({
+    where: { userId_familyId: { userId: user.id, familyId: target.familyId } },
+  });
+  const heartsAfter = after?.hearts ?? -1;
+  const delta = heartsAfter - heartsBefore;
+
+  console.log(`[verify-mg81] granted results = ${JSON.stringify(results)}`);
+  console.log(`[verify-mg81] hearts after = ${heartsAfter} (delta = ${delta})`);
+
+  const grantedCount = results.filter(Boolean).length;
+  const expectFirstTrueRestFalse =
+    results[0] === true && results.slice(1).every((b) => b === false);
+  const ok = expectFirstTrueRestFalse && delta === 1 && grantedCount === 1;
+
+  if (!ok) {
+    console.error('[verify-mg81] FAIL — idempotent 깨짐');
+    process.exit(1);
+  }
+  console.log('[verify-mg81] PASS — 첫 호출만 grant, 이후 idempotent, hearts +1');
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,7 +1,7 @@
 import prisma from '../utils/prisma';
 import { UserResponse, UpdateUserRequest } from '../models';
 import { Errors } from '../middleware/errorHandler';
-import { getKstToday } from '../utils/kst';
+import { getKstMidnightUtc } from '../utils/kst';
 import { resolveLocaleFromHeader } from '../utils/i18n/push';
 
 const MAX_AD_HEARTS = 5; // 1회 광고 시청 보상 최대 하트 수
@@ -92,19 +92,24 @@ export class UserService {
    *
    * hearts increment 도 같은 updateMany 안에 포함해 grant 와 +1 이 한
    * 트랜잭션·한 row 단위로 묶이게 한다 (분리하면 락 해제 사이 인터리빙 가능).
+   *
+   * cutoff 는 반드시 `getKstMidnightUtc()` 사용. lastHeartGrantedAt 은
+   * 시각 포함 DateTime 이라 `getKstToday()` 의 "KST 날짜를 UTC 자정 시각으로
+   * 표기" 패턴과 9시간 어긋나, KST 0~9시 윈도우에서 매 호출마다 grant 가
+   * 발생하던 결함이 있었음 (MG-81).
    */
   async grantDailyHeartIfNeeded(
     userPk: string,
     familyId: string
   ): Promise<{ granted: boolean }> {
-    const kstToday = getKstToday();
+    const cutoff = getKstMidnightUtc();
     const result = await prisma.familyMembership.updateMany({
       where: {
         userId: userPk,
         familyId,
         OR: [
           { lastHeartGrantedAt: null },
-          { lastHeartGrantedAt: { lt: kstToday } },
+          { lastHeartGrantedAt: { lt: cutoff } },
         ],
       },
       data: {

--- a/src/utils/kst.ts
+++ b/src/utils/kst.ts
@@ -12,11 +12,31 @@ const KST_TZ = 'Asia/Seoul';
 /**
  * KST 기준 "오늘" 을 UTC 자정으로 표현한 Date.
  * Prisma `@db.Date` 는 UTC 자정으로 저장되므로 비교/insert 에 안전.
+ *
+ * 주의: 시각 포함 DateTime (TIMESTAMP) 컬럼과의 cutoff 비교에는 쓰지 말 것.
+ * 반환값 `2026-04-28T00:00:00.000Z` 는 실제로는 KST 04-28 09:00 시각이라
+ * KST 0~9시 윈도우의 시각과 비교하면 9시간 어긋나 매번 미래로 보인다.
+ * 그 용도엔 `getKstMidnightUtc()` 사용.
  */
 export function getKstToday(): Date {
   const now = new Date();
   const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: KST_TZ });
   return new Date(kstDateStr + 'T00:00:00.000Z');
+}
+
+/**
+ * 현재 시각이 속한 KST 일자의 0시(자정)을 UTC Date 로 반환.
+ *
+ * 시각 포함 DateTime (Postgres TIMESTAMP) 컬럼과 cutoff 비교할 때 사용.
+ * `getKstToday()` 는 `@db.Date` 호환을 위해 KST 날짜를 UTC 자정 시각으로 표기하므로
+ * (예: KST 04-28 의도 → `2026-04-28T00:00:00.000Z` UTC = KST 09:00 시각)
+ * TIMESTAMP cutoff 에 그대로 쓰면 KST 0~9시 사이에 매 비교가 항상 과거로 판정되는
+ * off-by-9h 결함이 발생한다 (MG-81: 데일리 하트 매 호출 +1 버그).
+ */
+export function getKstMidnightUtc(): Date {
+  const now = new Date();
+  const kstDateStr = now.toLocaleDateString('en-CA', { timeZone: KST_TZ });
+  return new Date(kstDateStr + 'T00:00:00.000+09:00');
 }
 
 /**


### PR DESCRIPTION
## Jira
- [MG-81](https://ycompany.atlassian.net/browse/MG-81)

## Related
- 이전 트랙: MG-77 (PR #53 / iOS PR #112) — 서버 `dailyHeartGrantedNow` 옵트인 플래그 정합. 본 PR 은 그 플래그가 옳은 시점에만 true 가 되도록 cutoff 결함을 잡는다.
- MG-76 (PR #51) race-sim 의 inline cutoff 가 production 과 어긋나 KST 0~9시 윈도우에서 가짜 PASS 였음 — 본 PR 에서 정렬

## Summary
- KST 매일 0~9시 윈도우에 앱 진입 시 진입 횟수만큼 데일리 하트가 +1 누적되던 결함을 차단
- 원인: `getKstToday()` 가 KST 자정을 UTC 자정 시각으로 표기 (예: KST 04-28 → `2026-04-28T00:00:00.000Z` UTC = 실제 KST 09:00). 시각 포함 DateTime 인 `FamilyMembership.lastHeartGrantedAt` 와 비교 시 9시간 어긋나 매 호출이 cutoff 보다 과거로 판정 → 매번 grant
- `getKstMidnightUtc()` 신규 헬퍼 (ISO offset `+09:00`) 도입. `grantDailyHeartIfNeeded` 만 교체. 다른 사용처는 모두 `@db.Date` 컬럼 비교라 무영향
- `race-sim-record-access.ts` 도 동일 헬퍼로 정렬 (이전 inline `getKstToday` 가 결함을 그대로 복제)
- `verify-mg81-kst-window.ts` 회귀 검증 신규

## Test plan
- [x] verify-mg81: KST 04-28 00:33 (결함 윈도우 한복판) 5회 연속 → `[true,false,false,false,false]`, hearts +1
- [x] race-sim: 10 분리 PrismaClient 동시 호출 → delta=1 (PASS)
- [x] tsc --noEmit (회귀 0)
- [ ] deploy:dev → mrdydgjs 디바이스 KST 0~9시 윈도우 5회 진입 → hearts 단 1회 +1
- [ ] KST 09시 이후 동일 검증 (회귀 없음)
- [ ] deploy:prod → 동일 검증

## 회귀 영향 평가
| 사용처 | 컬럼 타입 | 영향 |
|---|---|---|
| `MoodService.upsert/getMoods` (`MoodRecord.date`) | `@db.Date` | 무 |
| `scheduler.assignDailyQuestions` (`DailyQuestion.date`) | `@db.Date` | 무 |
| `FamilyService.assignQuestionToFamily` (위와 동일) | `@db.Date` | 무 |
| `UserService.grantDailyHeartIfNeeded` (`FamilyMembership.lastHeartGrantedAt`) | `DateTime` | **수정 대상** |

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)