### PR TITLE
fix(push): 푸시 페이로드에 notificationId 추가 (MG-111)

### DIFF
--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -178,6 +178,9 @@ export async function sendDailyReminders(): Promise<void> {
   }
 
   // DB 알림 — (유저, 가족) 단위 1건. 본인이 해당 가족에서 미답변이면 미답변자 문구, 아니면 답변자 문구.
+  // 한 유저가 여러 가족 소속이면 여러 알림 생성되지만 푸시는 유저당 1회 발송 → 첫 알림 ID 만
+  // 페이로드 notificationId 로 포함해 클라가 자동 markAsRead. 나머지 가족 REMINDER 는 알림함에서 정리. (MG-111)
+  const firstNotifIdByUser = new Map<string, string>();
   const dbNotifTasks: Promise<unknown>[] = [];
   for (const entry of dbNotifByKey.values()) {
     const user = userInfoMap.get(entry.userId);
@@ -186,6 +189,11 @@ export async function sendDailyReminders(): Promise<void> {
     dbNotifTasks.push(
       notificationService
         .createNotification(entry.userId, 'REMINDER', title, body, entry.familyId)
+        .then((notifId) => {
+          if (!firstNotifIdByUser.has(entry.userId)) {
+            firstNotifIdByUser.set(entry.userId, notifId);
+          }
+        })
         .catch((e) => {
           console.warn('[Reminder] 알림 저장 실패:', e);
         })
@@ -215,6 +223,7 @@ export async function sendDailyReminders(): Promise<void> {
     const { title, body } = makeBody(user.locale, unanswered);
     const badgeCount = unreadByUser.get(userId) ?? 0;
 
+    const notifId = firstNotifIdByUser.get(userId);
     if (user.apnsToken) {
       pushTasks.push(
         pushService.sendApnsPush(
@@ -223,7 +232,8 @@ export async function sendDailyReminders(): Promise<void> {
           body,
           'REMINDER',
           badgeCount,
-          user.apnsEnvironment
+          user.apnsEnvironment,
+          notifId
         ).catch((e) => {
           console.warn('[Reminder] APNs 푸시 실패:', e);
         })
@@ -232,7 +242,7 @@ export async function sendDailyReminders(): Promise<void> {
     if (user.fcmToken) {
       pushTasks.push(
         pushService
-          .sendFcmPush(user.fcmToken, title, body, 'REMINDER')
+          .sendFcmPush(user.fcmToken, title, body, 'REMINDER', undefined, notifId)
           .catch((e) => {
             console.warn('[Reminder] FCM 푸시 실패:', e);
           })

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -116,16 +116,20 @@ export class AnswerService {
       // Lambda에서는 fire-and-forget 패턴이 안 됨 — 핸들러가 응답하면 runtime이 frozen 처리되어
       // 백그라운드 HTTP/2 APNs 연결이 중단됨. 모든 푸시 작업을 await 처리.
 
-      // 1단계: DB 알림 저장 (뱃지 카운트 조회 전에 완료해야 정확한 수치 반영)
+      // 1단계: DB 알림 저장 (뱃지 카운트 조회 전에 완료해야 정확한 수치 반영).
+      // 생성된 알림 ID 를 멤버별 Map 으로 캡쳐 → 푸시 페이로드의 notificationId 로 사용 (MG-111).
+      const notificationIdByMember = new Map<string, string>();
       const dbNotifTasks: Promise<unknown>[] = [];
       for (const member of otherMembers) {
         const msgs = getPushMessages(member.locale);
         const title = msgs.memberAnswered.title(senderNickname);
         const body = msgs.memberAnswered.body;
         dbNotifTasks.push(
-          notificationService.createNotification(member.id, 'MEMBER_ANSWERED', title, body, user.familyId, senderColorId).catch((e) => {
-            console.warn('[Answer] 알림 저장 실패:', e);
-          })
+          notificationService.createNotification(member.id, 'MEMBER_ANSWERED', title, body, user.familyId, senderColorId)
+            .then((notifId) => { notificationIdByMember.set(member.id, notifId); })
+            .catch((e) => {
+              console.warn('[Answer] 알림 저장 실패:', e);
+            })
         );
       }
       await Promise.all(dbNotifTasks);
@@ -139,12 +143,13 @@ export class AnswerService {
         const msgs = getPushMessages(member.locale);
         const title = msgs.memberAnswered.title(senderNickname);
         const body = msgs.memberAnswered.body;
+        const notifId = notificationIdByMember.get(member.id);
 
         if (member.apnsToken) {
           pushTasks.push(
             (async () => {
               const badgeCount = await notificationService.getUnreadCount(member.id);
-              await pushService.sendApnsPush(member.apnsToken!, title, body, 'MEMBER_ANSWERED', badgeCount, member.apnsEnvironment);
+              await pushService.sendApnsPush(member.apnsToken!, title, body, 'MEMBER_ANSWERED', badgeCount, member.apnsEnvironment, notifId);
             })().catch((e) => {
               console.warn('[Answer] APNs 푸시 실패:', e);
             })
@@ -152,7 +157,7 @@ export class AnswerService {
         }
         if (member.fcmToken) {
           pushTasks.push(
-            pushService.sendFcmPush(member.fcmToken, title, body, 'MEMBER_ANSWERED', senderColorId).catch((e) => {
+            pushService.sendFcmPush(member.fcmToken, title, body, 'MEMBER_ANSWERED', senderColorId, notifId).catch((e) => {
               console.warn('[Answer] FCM 푸시 실패:', e);
             })
           );

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -66,7 +66,8 @@ export class NotificationService {
     return { count: result.count };
   }
 
-  /** 내부적으로 알림 생성 (다른 서비스에서 호출) */
+  /** 내부적으로 알림 생성 (다른 서비스에서 호출). 생성된 알림 ID 를 반환해
+   *  푸시 페이로드에 notificationId 로 실어 보낼 수 있도록 한다 (MG-111). */
   async createNotification(
     userId: string,
     type: NotificationType,
@@ -74,8 +75,11 @@ export class NotificationService {
     body: string,
     familyId?: string,
     colorId?: string
-  ): Promise<void> {
-    await prisma.notification.create({ data: { userId, type, title, body, familyId: familyId ?? null, colorId: colorId ?? null } });
+  ): Promise<string> {
+    const created = await prisma.notification.create({
+      data: { userId, type, title, body, familyId: familyId ?? null, colorId: colorId ?? null },
+    });
+    return created.id;
   }
 
   /** 유저의 미읽음 알림 수 (뱃지 카운트용). userId 는 User.id (내부 UUID). 푸시 서비스용. */

--- a/src/services/NudgeService.ts
+++ b/src/services/NudgeService.ts
@@ -105,7 +105,8 @@ export class NudgeService {
     const nudgeTitle = msgs.nudge.title;
     const nudgeBody = msgs.nudge.body(senderNickname);
 
-    await notificationService.createNotification(
+    // 생성된 알림 ID 를 푸시 페이로드의 notificationId 로 전달 → 클라 자동 markAsRead (MG-111)
+    const nudgeNotificationId = await notificationService.createNotification(
       target.id,
       'ANSWER_REQUEST',
       nudgeTitle,
@@ -122,7 +123,7 @@ export class NudgeService {
         pushTasks.push(
           (async () => {
             const badgeCount = await notificationService.getUnreadCount(target.id);
-            await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment);
+            await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment, nudgeNotificationId);
           })().catch((e) => {
             console.warn('[Nudge] APNs 푸시 실패:', e);
           })
@@ -134,7 +135,9 @@ export class NudgeService {
             target.fcmToken,
             nudgeTitle,
             nudgeBody,
-            'ANSWER_REQUEST'
+            'ANSWER_REQUEST',
+            undefined,
+            nudgeNotificationId
           ).catch((e) => {
             console.warn('[Nudge] FCM 푸시 실패:', e);
           })

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -45,8 +45,9 @@ export class PushNotificationService {
     );
   }
 
-  /** FCM 푸시 알림 발송 (Android) */
-  async sendFcmPush(fcmToken: string, title: string, body: string, type: string, colorId?: string): Promise<void> {
+  /** FCM 푸시 알림 발송 (Android).
+   * notificationId 를 data 에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용 (MG-111). */
+  async sendFcmPush(fcmToken: string, title: string, body: string, type: string, colorId?: string, notificationId?: string): Promise<void> {
     initFirebase();
     if (admin.apps.length === 0) {
       console.warn('[FCM] Firebase 미초기화 — 푸시 발송 건너뜀');
@@ -56,7 +57,7 @@ export class PushNotificationService {
       await admin.messaging().send({
         token: fcmToken,
         notification: { title, body },
-        data: { type, ...(colorId && { colorId }) },
+        data: { type, ...(colorId && { colorId }), ...(notificationId && { notificationId }) },
         android: { priority: 'high' },
       });
     } catch (e: unknown) {
@@ -77,19 +78,22 @@ export class PushNotificationService {
 
   /** APNs 푸시 알림 범용 발송.
    * environment: 'sandbox' | 'production' — 유저 레코드에 저장된 값을 그대로 전달.
-   * 미지정(undefined/null) 시 서버의 NODE_ENV 기반 fallback을 사용. (MG-22) */
+   * 미지정(undefined/null) 시 서버의 NODE_ENV 기반 fallback을 사용. (MG-22)
+   * notificationId 를 페이로드에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용 (MG-111). */
   async sendApnsPush(
     deviceToken: string,
     title: string,
     body: string,
     type: string,
     badgeCount?: number,
-    environment?: 'sandbox' | 'production' | null
+    environment?: 'sandbox' | 'production' | null,
+    notificationId?: string
   ): Promise<void> {
     if (!this.keyId || !this.teamId || !this.bundleId || !this.rawKey) return;
     const payload = JSON.stringify({
       aps: { alert: { title, body }, sound: 'default', badge: badgeCount ?? 1 },
       type,
+      ...(notificationId && { notificationId }),
     });
     return this._sendApnsPayload(deviceToken, payload, environment);
   }
@@ -171,16 +175,19 @@ export class PushNotificationService {
     });
   }
 
-  /** 재촉하기 푸시 알림 발송 */
+  /** 재촉하기 푸시 알림 발송.
+   * notificationId 를 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용 (MG-111). */
   async sendNudgePush(
     deviceToken: string,
     senderName: string,
     badgeCount?: number,
-    environment?: 'sandbox' | 'production' | null
+    environment?: 'sandbox' | 'production' | null,
+    notificationId?: string
   ): Promise<void> {
     const payload = JSON.stringify({
       aps: { alert: { title: '재촉하기 알림', body: `${senderName}님이 오늘의 질문에 답변해달라고 합니다` }, sound: 'default', badge: badgeCount ?? 1 },
       type: 'ANSWER_REQUEST',
+      ...(notificationId && { notificationId }),
     });
     return this._sendApnsPayload(deviceToken, payload, environment);
   }

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -675,15 +675,19 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
 
   // 1단계: DB 알림 저장 — 푸시의 badge 카운트가 새 알림을 포함해 정확히 반영되도록
   // 모든 createNotification 을 먼저 await. AnswerService.MEMBER_ANSWERED 와 동일 패턴.
+  // 생성된 알림 ID 를 멤버별 Map 으로 캡쳐 → 푸시 페이로드의 notificationId 로 사용 (MG-111).
+  const notificationIdByMember = new Map<string, string>();
   const dbNotifTasks: Promise<unknown>[] = [];
   for (const m of members) {
     const msgs = getPushMessages(m.locale);
     const title = msgs.newQuestion.title;
     const body = msgs.newQuestion.body;
     dbNotifTasks.push(
-      notifSvc.createNotification(m.id, 'NEW_QUESTION', title, body, familyId).catch((e) => {
-        console.warn(`[notifyNewQuestion] DB 알림 실패 user=${m.id} family=${familyId}:`, e);
-      })
+      notifSvc.createNotification(m.id, 'NEW_QUESTION', title, body, familyId)
+        .then((notifId) => { notificationIdByMember.set(m.id, notifId); })
+        .catch((e) => {
+          console.warn(`[notifyNewQuestion] DB 알림 실패 user=${m.id} family=${familyId}:`, e);
+        })
     );
   }
   await Promise.all(dbNotifTasks);
@@ -696,12 +700,13 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
     const msgs = getPushMessages(m.locale);
     const title = msgs.newQuestion.title;
     const body = msgs.newQuestion.body;
+    const notifId = notificationIdByMember.get(m.id);
 
     if (m.apnsToken) {
       pushTasks.push(
         (async () => {
           const badge = await notifSvc.getUnreadCount(m.id);
-          await pushSvc.sendApnsPush(m.apnsToken!, title, body, 'NEW_QUESTION', badge, m.apnsEnvironment);
+          await pushSvc.sendApnsPush(m.apnsToken!, title, body, 'NEW_QUESTION', badge, m.apnsEnvironment, notifId);
         })().catch((e) => {
           console.warn(`[notifyNewQuestion] APNs 실패 user=${m.id}:`, e);
         })
@@ -709,7 +714,7 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
     }
     if (m.fcmToken) {
       pushTasks.push(
-        pushSvc.sendFcmPush(m.fcmToken, title, body, 'NEW_QUESTION').catch((e) => {
+        pushSvc.sendFcmPush(m.fcmToken, title, body, 'NEW_QUESTION', undefined, notifId).catch((e) => {
           console.warn(`[notifyNewQuestion] FCM 실패 user=${m.id}:`, e);
         })
       );


### PR DESCRIPTION
## Summary
- 알림 발송 시 생성된 `Notification.id` 를 푸시 페이로드에 동봉해 클라가 탭 시 자동 markAsRead 가능하게 함
- iOS#2 (앱아이콘 배지 안 없어짐) / iOS#3 (알림 탭 시 자동 읽음 처리) 의 서버 측 전제

## Changes
- `NotificationService.createNotification`: `Promise<void>` → `Promise<string>` (생성된 알림 ID 반환)
- `PushNotificationService.sendApnsPush/sendFcmPush/sendNudgePush`: `notificationId?: string` 파라미터 추가, payload data/aps top-level 에 포함
- `AnswerService` (MEMBER_ANSWERED), `NudgeService` (ANSWER_REQUEST), `QuestionService` (NEW_QUESTION), `reminderScheduler` (REMINDER): `createNotification` 결과를 멤버별 Map 으로 캡쳐 → 푸시 발송에 전달
- 사용자가 여러 가족 소속이라 푸시 1건 + 알림 N건이 되는 REMINDER 케이스는 첫 번째 ID 만 전달

## Side effects
- DB 알림 저장 흐름은 그대로, ID 캡쳐만 추가 (race 없음, 이미 모두 await 처리되던 코드)
- `notificationId` 가 없는 클라(구버전 앱) 는 페이로드 무시 → 기존 동작 유지 (서버 변경의 backward-compat)
- 동일 PR 의 클라이언트 변경(Mongle / Mongle-Android MG-111)이 함께 머지/배포되어야 사용자가 효과 체감

## Test plan
- [ ] `npx tsc --noEmit` (이미 통과)
- [ ] AnswerService / QuestionService / NotificationService 테스트 통과 (reminderScheduler 9건 사전 결함은 본 PR 범위 외)
- [ ] 답변 작성 → 다른 가족 멤버 푸시 페이로드에 `notificationId` 포함 여부 확인 (CloudWatch 로그)
- [ ] 재촉 발송 → 대상 푸시 페이로드 확인
- [ ] 새 질문 / 데일리 리마인더 동일 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)