### PR TITLE
fix(reminder-push): REMINDER push type 을 unanswered 여부로 suffix 분기 (MG-116)

### DIFF
--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -224,13 +224,18 @@ export async function sendDailyReminders(): Promise<void> {
     const badgeCount = unreadByUser.get(userId) ?? 0;
 
     const notifId = firstNotifIdByUser.get(userId);
+    // MG-116 — 클라가 알림 탭 시 본인 미답변 여부에 따라 답변 화면 vs 홈 화면으로 분기
+    // 할 수 있도록 push payload type 에 suffix 부여. DB Notification.type 은 'REMINDER'
+    // 그대로 유지(알림함 라우팅 영향 없음). 여러 가족 소속이면 어느 가족에서든
+    // 본인 미답변이 1건이라도 있으면 unanswered=true.
+    const pushType = unanswered ? 'REMINDER_UNANSWERED' : 'REMINDER_ANSWERED';
     if (user.apnsToken) {
       pushTasks.push(
         pushService.sendApnsPush(
           user.apnsToken!,
           title,
           body,
-          'REMINDER',
+          pushType,
           badgeCount,
           user.apnsEnvironment,
           notifId
@@ -242,7 +247,7 @@ export async function sendDailyReminders(): Promise<void> {
     if (user.fcmToken) {
       pushTasks.push(
         pushService
-          .sendFcmPush(user.fcmToken, title, body, 'REMINDER', undefined, notifId)
+          .sendFcmPush(user.fcmToken, title, body, pushType, undefined, notifId)
           .catch((e) => {
             console.warn('[Reminder] FCM 푸시 실패:', e);
           })


### PR DESCRIPTION
## Summary
- 클라가 REMINDER 알림 탭 시 본인 미답변 / 답변 완료 케이스로 라우팅 분기할 수 있도록 push payload type 에 suffix 부여
- DB `Notification.type` 은 'REMINDER' 그대로 (알림함 라우팅 영향 X)

## ⚠️ Stacked on #56
이 PR 의 base 는 `fix/MG-111-push-mark-read-on-tap` (#56). MG-111 머지 후 base 를 main 으로 변경 필요.

## Changes
| 케이스 | push type |
|---|---|
| 본인이 어느 가족에서든 미답변 1건+ | **REMINDER_UNANSWERED** |
| 본인 모든 답변 완료, 그룹 미답변자 안내 | **REMINDER_ANSWERED** |

## Side effects
- 구버전 클라(suffix 모름) 는 두 type 을 unknown 으로 처리 → 안전 측 home (backward-compat)
- DB Notification.type 은 'REMINDER' 그대로 유지 → 알림함 / NotificationType enum 변경 없음

## 의존
- iOS [Mongle MG-116] / AOS [Mongle-Android MG-116] 함께 머지/배포되면 완전 fix

## Test plan
- [x] `npx tsc --noEmit` 통과
- [ ] reminderScheduler 동작 시 본인 미답변 그룹 멤버 → APNs/FCM type=REMINDER_UNANSWERED
- [ ] 본인 답변 완료 그룹 멤버 → type=REMINDER_ANSWERED

🤖 Generated with [Claude Code](https://claude.com/claude-code)