### PR TITLE
fix(push): FCM 페이로드를 data-only 로 전환 (MG-111)

### DIFF
--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -46,7 +46,12 @@ export class PushNotificationService {
   }
 
   /** FCM 푸시 알림 발송 (Android).
-   * notificationId 를 data 에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용 (MG-111). */
+   * data-only 페이로드로 발송 — notification 필드를 함께 보내면 안드로이드 백그라운드/종료
+   * 상태에서 OS 자동 처리 경로로 빠져 onMessageReceived 가 호출되지 않고, 클라가 정의한
+   * mongle_default 채널 대신 시스템 폴백 채널이 사용돼 헤드업 미노출/제조사 백그라운드
+   * 제한 등으로 알림이 누락된다. data-only + high priority + ttl=0 으로 항상 클라가
+   * 알림을 빌드하도록 보장. (MG-111)
+   * notificationId 를 data 에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용. */
   async sendFcmPush(fcmToken: string, title: string, body: string, type: string, colorId?: string, notificationId?: string): Promise<void> {
     initFirebase();
     if (admin.apps.length === 0) {
@@ -56,9 +61,14 @@ export class PushNotificationService {
     try {
       await admin.messaging().send({
         token: fcmToken,
-        notification: { title, body },
-        data: { type, ...(colorId && { colorId }), ...(notificationId && { notificationId }) },
-        android: { priority: 'high' },
+        data: {
+          title,
+          body,
+          type,
+          ...(colorId && { colorId }),
+          ...(notificationId && { notificationId }),
+        },
+        android: { priority: 'high', ttl: 0 },
       });
     } catch (e: unknown) {
       const errorCode = (e as { code?: string })?.code;


### PR DESCRIPTION
## Summary
- 안드로이드 백그라운드/종료 상태에서 FCM `notification` 필드가 OS 자동 처리 경로로 분기돼 `onMessageReceived` 미호출 + 시스템 폴백 채널 사용으로 알림 누락되는 문제 차단
- `sendFcmPush` 페이로드에서 `notification` 필드를 제거하고 `title`/`body` 를 `data` 에 포함, `android.ttl=0` 추가
- 호출자 시그니처/iOS APNs 발송 로직은 변경 없음

## 배경
서버가 `notification` + `data` 혼합 페이로드를 보내면 안드로이드 클라이언트는 백그라운드일 때 `MongleFcmService.onMessageReceived` 를 호출하지 않고 OS 가 직접 트레이 알림을 만든다. 이 경로는 매니페스트의 `default_notification_channel_id` 메타데이터를 참조하는데 클라에 메타데이터가 없어 시스템 폴백 채널(`Miscellaneous`)로 떨어져 헤드업 미노출/제조사 백그라운드 제한으로 알림이 누락됐다.

`data-only + priority=high + ttl=0` 으로 발송하면 항상 `onMessageReceived` 가 호출되어 클라가 `mongle_default` (IMPORTANCE_HIGH) 채널 기반으로 알림을 직접 빌드하게 된다.

## 호환성
- 안드로이드 클라(`MongleFcmService.onMessageReceived`)는 이미 `message.data["title"] / ["body"]` fallback 코드를 가지고 있어 data-only 전환 후에도 정상 동작
- iOS 는 원래 `aps.alert` 만 사용하므로 영향 없음
- 호출 시그니처(`sendFcmPush(fcmToken, title, body, type, colorId?, notificationId?)`) 변경 없음 — `NudgeService`/`AnswerService`/`QuestionService`/`reminderScheduler` 모두 그대로 동작

## Test plan
- [ ] Android 포그라운드 / 백그라운드 / 앱 종료(스와이프) 상태에서 재촉 수신 → 트레이 알림 표시 확인
- [ ] Android Doze/배터리세이버 상태에서 재촉 수신 → 즉시 표시 확인
- [ ] Firebase Console / logcat 으로 송신 패킷에 `notification` 필드 부재 확인
- [ ] iOS 재촉/새 답변/새 질문 회귀 없음 (`aps.alert` 그대로 표시)
- [ ] Quiet Hours, `notifNudge` OFF 등 기존 필터링 정상 작동
- [ ] 만료 토큰 정리 로직(invalid-registration-token → fcmToken=null) 정상 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)