### PR TITLE
fix(notification): unread/list 쿼리에 user.createdAt + 14일 TTL 컷오프 (MG-127)

### DIFF
--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -107,13 +107,16 @@ describe('sendDailyReminders (MG-19)', () => {
       'fam-1'
     );
     expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+    // MG-116: push payload type 은 'REMINDER_UNANSWERED' / 'REMINDER_ANSWERED' 분기 (DB type 은 'REMINDER').
+    // MG-111: 마지막 인자 notifId — mocked createNotification 이 undefined 반환.
     expect(mockSendApnsPush).toHaveBeenCalledWith(
       'apns-token',
       '오늘 질문에 답변하지 않았어요',
       '그룹에 접속해서 답변을 달아봐요',
-      'REMINDER',
+      'REMINDER_UNANSWERED',
       0,
-      'production'
+      'production',
+      undefined
     );
     expect(mockSendFcmPush).not.toHaveBeenCalled();
   });
@@ -185,10 +188,11 @@ describe('sendDailyReminders (MG-19)', () => {
     const user2Push = mockSendApnsPush.mock.calls.find((c) => c[0] === 'apns-2');
     expect(user1Push).toBeDefined();
     expect(user1Push![1]).toBe('미답변자가 있어요');
-    expect(user1Push![3]).toBe('REMINDER');
+    // MG-116: 답변자 → REMINDER_ANSWERED, 미답변자 → REMINDER_UNANSWERED (push payload type).
+    expect(user1Push![3]).toBe('REMINDER_ANSWERED');
     expect(user2Push).toBeDefined();
     expect(user2Push![1]).toBe('오늘 질문에 답변하지 않았어요');
-    expect(user2Push![3]).toBe('REMINDER');
+    expect(user2Push![3]).toBe('REMINDER_UNANSWERED');
   });
 
   it('동일 유저의 미답변 복수 건이어도 (유저, 가족) 단위 1건으로 통합된다', async () => {
@@ -264,11 +268,14 @@ describe('sendDailyReminders (MG-19)', () => {
 
     expect(mockSendApnsPush).not.toHaveBeenCalled();
     expect(mockSendFcmPush).toHaveBeenCalledTimes(1);
+    // sendFcmPush(token, title, body, type, data, notifId) — MG-116/MG-111 인자 추가 반영.
     expect(mockSendFcmPush).toHaveBeenCalledWith(
       'fcm-token',
       '오늘 질문에 답변하지 않았어요',
       '그룹에 접속해서 답변을 달아봐요',
-      'REMINDER'
+      'REMINDER_UNANSWERED',
+      undefined,
+      undefined
     );
   });
 

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -201,18 +201,18 @@ export async function sendDailyReminders(): Promise<void> {
   }
   await Promise.all(dbNotifTasks);
 
-  // 배치 조회 ④: badge 카운트 N+1 제거. 푸시 대상 전체의 unread 를 한 번의 groupBy 로
-  // 조회 후 Map 으로 사용. 이전엔 user 마다 getUnreadCount 호출로 N 회 쿼리 발생.
+  // badge 카운트 — NotificationService.getUnreadCount 로 통일 (MG-127).
+  // 이전 batch groupBy 는 user.createdAt / 14일 TTL 컷오프를 우회해 가입 이전 알림과
+  // 오래된 누적이 푸시 페이로드 badge 에 그대로 박혔음. user 별 가변 컷오프는
+  // groupBy 로 표현 불가 → 메서드 재사용 + Promise.all 병렬로 round trip 평탄화.
   const pushUserIds = Array.from(userInfoMap.keys());
-  const unreadCounts = await prisma.notification.groupBy({
-    by: ['userId'],
-    where: { userId: { in: pushUserIds }, isRead: false },
-    _count: { _all: true },
-  });
   const unreadByUser = new Map<string, number>();
-  for (const row of unreadCounts) {
-    unreadByUser.set(row.userId, row._count._all);
-  }
+  await Promise.all(
+    pushUserIds.map(async (uid) => {
+      const cnt = await notificationService.getUnreadCount(uid);
+      unreadByUser.set(uid, cnt);
+    })
+  );
 
   // 푸시 — 유저당 1회. 유저가 어느 가족에서든 미답변이면 미답변자 문구 사용(본인 답변이 더 긴급).
   const pushTasks: Promise<unknown>[] = [];

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -2,6 +2,14 @@ import { NotificationType, PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
+/** unread/list 컷오프 — max(user.createdAt, now() - 14d). 가입 이전 알림과
+ *  14일 이전 누적을 카운트/표시에서 제외 (MG-127). */
+const UNREAD_TTL_DAYS = 14;
+function computeUnreadCutoff(userCreatedAt: Date): Date {
+  const ttlCutoff = new Date(Date.now() - UNREAD_TTL_DAYS * 24 * 60 * 60 * 1000);
+  return userCreatedAt > ttlCutoff ? userCreatedAt : ttlCutoff;
+}
+
 export interface NotificationDTO {
   id: string;
   userId: string;
@@ -20,8 +28,13 @@ export class NotificationService {
     // authUserId는 JWT의 OAuth userId (예: "kakao:xxx"), Notification.userId는 User.id(UUID) FK
     const user = await prisma.user.findUnique({ where: { userId: authUserId } });
     if (!user) return [];
+    const cutoff = computeUnreadCutoff(user.createdAt);
     const items = await prisma.notification.findMany({
-      where: { userId: user.id, ...(familyId ? { familyId } : {}) },
+      where: {
+        userId: user.id,
+        createdAt: { gt: cutoff },
+        ...(familyId ? { familyId } : {}),
+      },
       orderBy: { createdAt: 'desc' },
       take: limit,
     });
@@ -82,16 +95,31 @@ export class NotificationService {
     return created.id;
   }
 
-  /** 유저의 미읽음 알림 수 (뱃지 카운트용). userId 는 User.id (내부 UUID). 푸시 서비스용. */
+  /** 유저의 미읽음 알림 수 (뱃지 카운트용). userId 는 User.id (내부 UUID). 푸시 서비스용.
+   *  user.createdAt + 14일 TTL 컷오프 적용 (MG-127). */
   async getUnreadCount(userId: string): Promise<number> {
-    return prisma.notification.count({ where: { userId, isRead: false } });
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true },
+    });
+    if (!user) return 0;
+    const cutoff = computeUnreadCutoff(user.createdAt);
+    return prisma.notification.count({
+      where: { userId, isRead: false, createdAt: { gt: cutoff } },
+    });
   }
 
   /** 인증된 사용자의 미읽음 알림 수. iOS 가 OS 배지 동기화 시 호출 (50건 캡 우회용). */
   async getUnreadCountForAuthUser(authUserId: string): Promise<number> {
-    const user = await prisma.user.findUnique({ where: { userId: authUserId }, select: { id: true } });
+    const user = await prisma.user.findUnique({
+      where: { userId: authUserId },
+      select: { id: true, createdAt: true },
+    });
     if (!user) return 0;
-    return prisma.notification.count({ where: { userId: user.id, isRead: false } });
+    const cutoff = computeUnreadCutoff(user.createdAt);
+    return prisma.notification.count({
+      where: { userId: user.id, isRead: false, createdAt: { gt: cutoff } },
+    });
   }
 
   private toDTO(n: { id: string; userId: string; familyId: string | null; colorId?: string | null; type: NotificationType; title: string; body: string; isRead: boolean; createdAt: Date }): NotificationDTO {


### PR DESCRIPTION
## Summary
- 신규 가입자에게 **가입 이전 일자**의 미읽음 알림이 누적되어 iOS OS 배지가 실제보다 큰 숫자(예: 38)로 표시되던 문제 수정
- `NotificationService` 의 unread/list 쿼리 `where` 에 `max(user.createdAt, now()-14d)` 컷오프 추가
- `reminderScheduler` 의 batch unread groupBy 도 `NotificationService.getUnreadCount` 로 통일 → 푸시 페이로드 badge 와 정의 일치

## 원인

서버에는 두 자동 메커니즘이 매일 가족당 미읽음 알림 row 를 누적시킴:

| 함수 | 위치 | 매일 생성 |
|---|---|---|
| `notifyNewQuestion` | `QuestionService.ts:649` | 가족 멤버 전원에게 `NEW_QUESTION` |
| `sendDailyReminders` | `reminderScheduler.ts` | 가족에 미답변자 ≥ 1 이면 답변자 포함 **전원**에게 `REMINDER` |

→ 하루 2건 × 가족 수 누적. 19일이면 ≈38개. 본인이 매일 답변해도 다른 가족 멤버 미답변 시 REMINDER 가 와 사용자 인식과 격차 발생.

`getUnreadCount` 와 `getNotifications` 가 단순 `isRead=false` 만 조건으로 하므로, 신규 가입자에게도 가입 이전 backfill·다른 멤버 행위로 만들어진 row 가 그대로 카운트됨.

## 수정

```typescript
const UNREAD_TTL_DAYS = 14;
function computeUnreadCutoff(userCreatedAt: Date): Date {
  const ttlCutoff = new Date(Date.now() - UNREAD_TTL_DAYS * 24 * 60 * 60 * 1000);
  return userCreatedAt > ttlCutoff ? userCreatedAt : ttlCutoff;
}
```

3개 메서드의 `where.createdAt` 에 `{ gt: cutoff }` 추가:
- `getNotifications(authUserId, limit, familyId)` — 알림함 표시 일관성
- `getUnreadCount(userId)` — 서버 내부 푸시 페이로드용
- `getUnreadCountForAuthUser(authUserId)` — iOS OS 배지 동기화용

`reminderScheduler.ts` 의 batch `groupBy` 는 컷오프를 우회하므로 `notificationService.getUnreadCount` 로 일관화 (Promise.all 병렬). 푸시 페이로드 badge 가 동일 정의를 따르게 됨.

## 변경 파일
- `src/services/NotificationService.ts` (+27 / -4)
- `src/reminderScheduler.ts` (+9 / -7)
- `src/__tests__/reminderScheduler.test.ts` (+19 / -9) — stale 어셔션 동반 fix

## 테스트 결과

| | main (사전) | 본 PR |
|---|---|---|
| 전체 테스트 fail | 13 | **4** |
| reminderScheduler fail | 9 | **0** |
| NotificationService fail | 0 | 0 |

남은 4개 fail (AuthService 1 + FamilyService 3) 는 main 에 pre-existing 이며 본 PR scope 외 — 별도 cleanup 티켓 권장.

## reminderScheduler 테스트 stale 어셔션 동반 fix

main 의 reminderScheduler 9 fail 분석:
- 6개: 본 PR 의 batch groupBy → `getUnreadCount` 통일로 자동 해소 (groupBy mock 누락이 원인이었음)
- 3개: push type 어셔션이 `'REMINDER'` 만 expect — **MG-116 도입 시 누락된 stale**

```typescript
// MG-116: push payload type 은 REMINDER_UNANSWERED / REMINDER_ANSWERED 로 분기
expect(user1Push![3]).toBe('REMINDER_ANSWERED');   // 답변자
expect(user2Push![3]).toBe('REMINDER_UNANSWERED'); // 미답변자
// MG-111: 마지막 인자에 notifId 추가
```

## Test plan
- [ ] 신규 가입자(가입 후 1일) → unread count 가 가입 이전 createdAt 알림을 포함하지 않음
- [ ] 14일 이전 createdAt 알림이 unread count 에서 제외됨
- [ ] `GET /notifications` 응답과 `GET /notifications/unread-count` 가 동일 컷오프 적용 (정의 일치)
- [ ] 매일 19시 reminder 푸시의 `aps.badge` 페이로드가 컷오프 적용된 값과 일치
- [ ] 정상 시나리오 (최근 1일 미읽음 1건) → unread = 1
- [ ] DB 의 알림 row 자체는 보존 (admin 회수 가능)

## 함께 봐야 할 PR / 티켓

- **[MG-126](https://ycompany.atlassian.net/browse/MG-126) — iOS 클라 출처 통일** (이미 PR #125 머지/대기)
  본 PR 과 결합해야 사용자 입장에서 정상 숫자가 표시됨.
- **[MG-128](https://ycompany.atlassian.net/browse/MG-128) — REMINDER 익일 자동 isRead=true cron** (follow-up)

Jira: [MG-127](https://ycompany.atlassian.net/browse/MG-127)

🤖 Generated with [Claude Code](https://claude.com/claude-code)