### PR TITLE
fix(reminder): 멤버십 합류 시점 이전 DQ 는 발송 대상 제외 (MG-129)

### DIFF
--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -32,6 +32,10 @@ jest.mock('../services/PushNotificationService', () => ({
 
 import { sendDailyReminders, getKstMidnightUtc } from '../reminderScheduler';
 
+// 모든 테스트의 default — 멤버십이 충분히 오래 전부터 존재했다고 가정.
+// 신규 합류자 케이스에서만 createdAt 을 dq.date 이후로 명시 설정해 검증 (MG-129).
+const PAST_JOINED_AT = new Date('2020-01-01');
+
 const mockUser = {
   id: 'user-1',
   apnsToken: 'apns-token',
@@ -92,7 +96,7 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([]);
 
@@ -126,7 +130,7 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
 
@@ -142,7 +146,7 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: dqDate },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: dqDate, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: dqDate, joinedAt: PAST_JOINED_AT, user: mockUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([]);
 
@@ -157,8 +161,8 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: otherUser },
     ]);
     // user-1 답변, user-2 미답변
     mockAnswerFindMany.mockResolvedValue([{ questionId: 'q-1', userId: 'user-1' }]);
@@ -202,7 +206,7 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-3', questionId: 'q-3', familyId: 'fam-1', date: new Date('2026-04-15') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([]);
 
@@ -219,8 +223,8 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-B', questionId: 'q-B', familyId: 'fam-B', date: new Date('2026-04-17') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-A', skippedDate: null, user: mockUser },
-      { userId: 'user-1', familyId: 'fam-B', skippedDate: null, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-A', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
+      { userId: 'user-1', familyId: 'fam-B', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([]);
 
@@ -239,6 +243,7 @@ describe('sendDailyReminders (MG-19)', () => {
         userId: 'user-1',
         familyId: 'fam-1',
         skippedDate: null,
+        joinedAt: PAST_JOINED_AT,
         user: { ...mockUser, notifQuestion: false },
       },
     ]);
@@ -259,6 +264,7 @@ describe('sendDailyReminders (MG-19)', () => {
         userId: 'user-1',
         familyId: 'fam-1',
         skippedDate: null,
+        joinedAt: PAST_JOINED_AT,
         user: { ...mockUser, apnsToken: null, fcmToken: 'fcm-token' },
       },
     ]);
@@ -285,8 +291,8 @@ describe('sendDailyReminders (MG-19)', () => {
       { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: new Date('2026-04-17') },
     ]);
     mockMembershipFindMany.mockResolvedValue([
-      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, user: mockUser },
-      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, user: otherUser },
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: otherUser },
     ]);
     mockAnswerFindMany.mockResolvedValue([
       { questionId: 'q-1', userId: 'user-1' },
@@ -297,5 +303,56 @@ describe('sendDailyReminders (MG-19)', () => {
 
     expect(mockCreateNotification).not.toHaveBeenCalled();
     expect(mockSendApnsPush).not.toHaveBeenCalled();
+  });
+
+  // MG-129: 신규 합류자가 가족의 historical DQ (자신의 가입 이전 일자) 에 대해 reminder 를
+  // 받던 결함 차단. unfinished 판정과 발송 대상 등록 루프 양쪽에 멤버십 시점 필터 적용.
+  it('신규 합류자(membership.createdAt > dq.date) 는 historical DQ 에 대해 reminder 받지 않음 (MG-129)', async () => {
+    // 가족이 며칠 전부터 운영 중 → 최신 DQ 의 date 는 신규 합류자 가입 이전.
+    const dqDate = new Date('2026-04-15');
+    const newJoinerJoinedAt = new Date('2026-04-17'); // dq.date 이후 합류
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: dqDate },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: newJoinerJoinedAt, user: mockUser },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    // 신규 합류자만 있고 그가 dq.date 이후 합류 → unfinished.length === 0 → 발송 skip
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockSendApnsPush).not.toHaveBeenCalled();
+  });
+
+  it('기존 멤버 + 신규 합류자 혼재 시, 기존 멤버에게만 reminder 발송 (MG-129)', async () => {
+    const dqDate = new Date('2026-04-15');
+    const newJoinerJoinedAt = new Date('2026-04-17'); // dq.date 이후 합류
+    const newJoiner = { ...mockUser, id: 'user-2', apnsToken: 'apns-2' };
+    mockDQFindMany.mockResolvedValue([
+      { id: 'dq-1', questionId: 'q-1', familyId: 'fam-1', date: dqDate },
+    ]);
+    mockMembershipFindMany.mockResolvedValue([
+      // 기존 멤버 — 가입 시점 dq.date 이전, 미답변
+      { userId: 'user-1', familyId: 'fam-1', skippedDate: null, joinedAt: PAST_JOINED_AT, user: mockUser },
+      // 신규 합류자 — 가입 시점 dq.date 이후, 답변 의무 없음
+      { userId: 'user-2', familyId: 'fam-1', skippedDate: null, joinedAt: newJoinerJoinedAt, user: newJoiner },
+    ]);
+    mockAnswerFindMany.mockResolvedValue([]);
+
+    await sendDailyReminders();
+
+    // 기존 멤버에게만 발송, 신규 합류자에게는 안 감.
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      'user-1',
+      'REMINDER',
+      expect.any(String),
+      expect.any(String),
+      'fam-1'
+    );
+    expect(mockSendApnsPush).toHaveBeenCalledTimes(1);
+    expect(mockSendApnsPush.mock.calls[0][0]).toBe('apns-token'); // user-1 의 토큰
   });
 });

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -76,6 +76,7 @@ export async function sendDailyReminders(): Promise<void> {
       userId: true,
       familyId: true,
       skippedDate: true,
+      joinedAt: true, // MG-129: 합류 시점 이전 DQ 는 답변 의무 없음 — 필터에 사용
       user: {
         select: {
           id: true,
@@ -137,9 +138,15 @@ export async function sendDailyReminders(): Promise<void> {
 
     const answeredSet = answeredByQuestion.get(dq.questionId);
 
-    // 이 질문의 미답변자(skip 제외) — 1명 이상이어야 리마인드 발송
+    // 이 질문의 미답변자(skip 제외) — 1명 이상이어야 리마인드 발송.
+    // 멤버십 합류 시점 이전 DQ 는 답변 의무 없음 (MG-129) — 신규 가입자가 가족의
+    // 가장 최신 DQ 가 자신의 가입 이전 일자일 때 "오늘 답변 안 함" reminder 를
+    // 받던 결함 차단.
     const unfinished = memberships.filter(
-      (m) => !(answeredSet?.has(m.userId) ?? false) && !isSameDate(m.skippedDate, dq.date)
+      (m) =>
+        !(answeredSet?.has(m.userId) ?? false) &&
+        !isSameDate(m.skippedDate, dq.date) &&
+        m.joinedAt <= dq.date
     );
     if (unfinished.length === 0) continue;
 
@@ -149,6 +156,8 @@ export async function sendDailyReminders(): Promise<void> {
       if (!user) continue;
       // skip 멤버는 본인 의사로 오늘 건너뛰기 했으므로 리마인드 대상에서 제외
       if (isSameDate(m.skippedDate, dq.date)) continue;
+      // 합류 시점 이후의 DQ 에만 답변 의무 — 가입 이전 DQ 는 발송 대상 제외 (MG-129)
+      if (m.joinedAt > dq.date) continue;
 
       if (!userInfoMap.has(m.userId)) userInfoMap.set(m.userId, user);
 


### PR DESCRIPTION
> ⚠️ **Stack PR** — base: `fix/MG-127-server-unread-cutoff` (PR #61). MG-127 머지 후 GitHub 이 자동으로 base 를 main 으로 변경합니다. MG-127 과 같은 파일(`reminderScheduler.ts`) 의 다른 라인이라 conflict 위험 낮음.

## Summary
- 신규 회원이 가족에 합류한 직후 자신의 **가입 이전 일자** DQ 에 대해 "오늘 답변 안 함" REMINDER 를 받던 결함 수정
- `reminderScheduler` 의 미답변자 분류 로직에 **`FamilyMembership.joinedAt` ≤ `DailyQuestion.date`** 조건 추가
- DQ 발행 당시 가족 멤버였던 사람만 답변 의무 — 정의를 코드에 그대로 반영

## 사용자 증상
> "신규 회원임에도 오늘 질문에 답변하지 않았다는 가입 이전의 알림이 계속 오는거야"

신규 합류자 X 가 가입 D-1 의 DQ 에 대해 답변 기록이 없으니 "미답변자" 로 분류되어 19시 reminder 발송. X 입장: 자신이 가입조차 안 했던 시점의 질문에 대해 reminder 가 옴 → 부조리.

## MG-127 으로 해결되지 않는 이유
MG-127 은 **알림 row 의 `createdAt` 컷오프**. 위 reminder 는 createdAt 이 가입 이후이므로 컷오프를 정상 통과 → 카운트/표시에 그대로 들어옴. **대상자 분류 로직 자체의 결함**이라 별도 수정 필요.

## 변경

### `src/reminderScheduler.ts`

```diff
 select: {
   userId: true,
   familyId: true,
   skippedDate: true,
+  joinedAt: true,
   user: { ... },
 }
```

```diff
 const unfinished = memberships.filter(
   (m) =>
     !(answeredSet?.has(m.userId) ?? false) &&
-    !isSameDate(m.skippedDate, dq.date)
+    !isSameDate(m.skippedDate, dq.date) &&
+    m.joinedAt <= dq.date
 );
```

```diff
 for (const m of memberships) {
   if (isSameDate(m.skippedDate, dq.date)) continue;
+  if (m.joinedAt > dq.date) continue;  // 합류 이전 DQ 제외
   ...
 }
```

> Prisma 스키마의 `FamilyMembership` 은 `createdAt` 이 아니라 **`joinedAt`** 필드를 사용. 변수명도 `joinedAt` 으로 통일.

### `src/__tests__/reminderScheduler.test.ts`

- `PAST_JOINED_AT` helper 도입 (모든 default mockMembership 의 합류 시점)
- 모든 기존 mockMembership 에 `joinedAt` 주입 (회귀 없음 보장)
- **신규 테스트 케이스 2건 추가**:
  - `신규 합류자(joinedAt > dq.date) 는 historical DQ 에 대해 reminder 받지 않음` — 단독 시나리오, 발송 자체 skip
  - `기존 멤버 + 신규 합류자 혼재 시, 기존 멤버에게만 reminder 발송` — 부분 발송 시나리오

## NEW_QUESTION 은 영향 없음
`notifyNewQuestion(familyId)` 은 새 DQ 발행 **시점에만** 호출되므로, 그 시점의 멤버에게만 발송. 합류 이후 만들어진 DQ 만 카운트되므로 본 결함과 무관.

## 테스트 결과

| | 본 PR | 비고 |
|---|---|---|
| reminderScheduler suite | **14/14 ✅** (12 → 14, 신규 2건) | |
| NotificationService suite | **15/15 ✅** | (MG-127 패치 영향) |
| 전체 fail | 4 | AuthService 1 + FamilyService 3 — main pre-existing, 본 PR scope 외 |
| 회귀 | **0건** | |

## Test plan

- [ ] 신규 합류자가 가족의 historical DQ 에 대해 reminder 받지 않음
- [ ] 합류 시점 이전부터 가족이었던 멤버는 정상적으로 미답변자 분류 → reminder 수신
- [ ] 모든 멤버가 신규 합류자(joinedAt > dq.date)면 unfinished.length === 0 으로 발송 skip
- [ ] `notifyNewQuestion` 경로 회귀 없음 (새 DQ 발행 시 그 시점 멤버에게 정상 발송)

## 머지 순서 권장

1. **#61 (MG-127)** — 본 PR 의 base
2. **본 PR (MG-129)** — base 자동으로 main 으로 변경됨
3. **#125 (MG-126, iOS)** — 클라 출처 통일
4. **MG-128 (REMINDER 자동 read cron)** — follow-up 별도 PR

세 PR 모두 적용되어야 사용자 호소 증상이 완전히 해소됩니다.

Jira: [MG-129](https://ycompany.atlassian.net/browse/MG-129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)