### PR TITLE
fix(push): FCM 페이로드에 notificationCount 추가 (MG-130)

### DIFF
--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -274,14 +274,15 @@ describe('sendDailyReminders (MG-19)', () => {
 
     expect(mockSendApnsPush).not.toHaveBeenCalled();
     expect(mockSendFcmPush).toHaveBeenCalledTimes(1);
-    // sendFcmPush(token, title, body, type, data, notifId) — MG-116/MG-111 인자 추가 반영.
+    // sendFcmPush(token, title, body, type, colorId, notifId, unreadCount) — MG-130 unreadCount 추가.
     expect(mockSendFcmPush).toHaveBeenCalledWith(
       'fcm-token',
       '오늘 질문에 답변하지 않았어요',
       '그룹에 접속해서 답변을 달아봐요',
       'REMINDER_UNANSWERED',
       undefined,
-      undefined
+      undefined,
+      0
     );
   });
 

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -256,7 +256,7 @@ export async function sendDailyReminders(): Promise<void> {
     if (user.fcmToken) {
       pushTasks.push(
         pushService
-          .sendFcmPush(user.fcmToken, title, body, pushType, undefined, notifId)
+          .sendFcmPush(user.fcmToken, title, body, pushType, undefined, notifId, badgeCount)
           .catch((e) => {
             console.warn('[Reminder] FCM 푸시 실패:', e);
           })

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -157,7 +157,10 @@ export class AnswerService {
         }
         if (member.fcmToken) {
           pushTasks.push(
-            pushService.sendFcmPush(member.fcmToken, title, body, 'MEMBER_ANSWERED', senderColorId, notifId).catch((e) => {
+            (async () => {
+              const unreadCount = await notificationService.getUnreadCount(member.id);
+              await pushService.sendFcmPush(member.fcmToken!, title, body, 'MEMBER_ANSWERED', senderColorId, notifId, unreadCount);
+            })().catch((e) => {
               console.warn('[Answer] FCM 푸시 실패:', e);
             })
           );

--- a/src/services/NudgeService.ts
+++ b/src/services/NudgeService.ts
@@ -131,14 +131,18 @@ export class NudgeService {
       }
       if (target.fcmToken) {
         pushTasks.push(
-          pushService.sendFcmPush(
-            target.fcmToken,
-            nudgeTitle,
-            nudgeBody,
-            'ANSWER_REQUEST',
-            undefined,
-            nudgeNotificationId
-          ).catch((e) => {
+          (async () => {
+            const unreadCount = await notificationService.getUnreadCount(target.id);
+            await pushService.sendFcmPush(
+              target.fcmToken!,
+              nudgeTitle,
+              nudgeBody,
+              'ANSWER_REQUEST',
+              undefined,
+              nudgeNotificationId,
+              unreadCount
+            );
+          })().catch((e) => {
             console.warn('[Nudge] FCM 푸시 실패:', e);
           })
         );

--- a/src/services/PushNotificationService.ts
+++ b/src/services/PushNotificationService.ts
@@ -51,8 +51,10 @@ export class PushNotificationService {
    * mongle_default 채널 대신 시스템 폴백 채널이 사용돼 헤드업 미노출/제조사 백그라운드
    * 제한 등으로 알림이 누락된다. data-only + high priority + ttl=0 으로 항상 클라가
    * 알림을 빌드하도록 보장. (MG-111)
-   * notificationId 를 data 에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용. */
-  async sendFcmPush(fcmToken: string, title: string, body: string, type: string, colorId?: string, notificationId?: string): Promise<void> {
+   * notificationId 를 data 에 포함해 클라가 알림 탭 시 자동 markAsRead 호출에 사용.
+   * unreadCount 를 notificationCount 로 함께 보내 클라가 setNumber() / 런처 배지에 그대로
+   * 반영하도록 한다 — 클라 자체 increment 로 누적되던 서버↔런처 불일치 해소 (MG-130). */
+  async sendFcmPush(fcmToken: string, title: string, body: string, type: string, colorId?: string, notificationId?: string, unreadCount?: number): Promise<void> {
     initFirebase();
     if (admin.apps.length === 0) {
       console.warn('[FCM] Firebase 미초기화 — 푸시 발송 건너뜀');
@@ -67,6 +69,7 @@ export class PushNotificationService {
           type,
           ...(colorId && { colorId }),
           ...(notificationId && { notificationId }),
+          ...(typeof unreadCount === 'number' && { notificationCount: String(unreadCount) }),
         },
         android: { priority: 'high', ttl: 0 },
       });

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -714,7 +714,10 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
     }
     if (m.fcmToken) {
       pushTasks.push(
-        pushSvc.sendFcmPush(m.fcmToken, title, body, 'NEW_QUESTION', undefined, notifId).catch((e) => {
+        (async () => {
+          const unreadCount = await notifSvc.getUnreadCount(m.id);
+          await pushSvc.sendFcmPush(m.fcmToken!, title, body, 'NEW_QUESTION', undefined, notifId, unreadCount);
+        })().catch((e) => {
           console.warn(`[notifyNewQuestion] FCM 실패 user=${m.id}:`, e);
         })
       );


### PR DESCRIPTION
## Summary
- `sendFcmPush` 시그니처에 `unreadCount?: number` 추가, data 페이로드에 `notificationCount: String(unreadCount)` 포함 (값이 number 일 때만 — 하위 호환 보존)
- 4개 호출자(AnswerService / NudgeService / QuestionService / reminderScheduler) 에서 `getUnreadCount()` 결과를 FCM 호출에 전달
- Android 클라(`MongleFcmService`) 가 자체 `incrementAndGet()` 대신 서버 값을 source-of-truth 로 사용하도록 별도 PR(Android MG-130) 진행

## 원인
Android 클라가 push 수신마다 자체 카운트해 setNumber() 호출. 서버 실제 unread count 와 어긋날 수 있고, 다른 기기에서 읽음 처리되거나 14일 TTL 만료가 일어나도 따라잡지 못함.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx jest` — 56/56 PASS (reminderScheduler 인자 검증에 unreadCount=0 추가)
- [ ] dev 환경 배포 후 Android 기기로 푸시 수신 → `notificationCount` data 필드가 실린지 확인
- [ ] APNs 영향 없음 확인 (이미 `aps.badge` 로 unreadCount 전송 중)

🤖 Generated with [Claude Code](https://claude.com/claude-code)