### PR TITLE
feat(config): 클라이언트 광고 노출 제어용 /config 엔드포인트 신설 (MG-131)

### DIFF
--- a/src/controllers/ConfigController.ts
+++ b/src/controllers/ConfigController.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Route, Tags, SuccessResponse } from 'tsoa';
+
+interface ConfigResponse {
+  isAdEnabled: boolean;
+}
+
+@Route('config')
+@Tags('Config')
+export class ConfigController extends Controller {
+  /**
+   * 앱 부팅 시 호출되는 클라이언트 설정. 인증 불필요.
+   * isAdEnabled=false 면 클라는 광고 배너 렌더링과 AdMob 초기화를 모두 건너뛴다 (MG-132).
+   * 환경변수 ADS_ENABLED 미설정 시 true (기존 동작 유지).
+   * @summary 클라이언트 설정 조회
+   */
+  @Get()
+  @SuccessResponse(200, '성공')
+  public async getConfig(): Promise<ConfigResponse> {
+    const raw = process.env.ADS_ENABLED;
+    const isAdEnabled = raw === undefined ? true : raw.toLowerCase() === 'true';
+    return { isAdEnabled };
+  }
+}


### PR DESCRIPTION
## Summary
- `GET /config` 신설 (인증 불필요, 앱 부팅 시 1회 호출)
- 응답: `{ isAdEnabled: boolean }`
- 기준: 환경변수 `ADS_ENABLED` (대소문자 무시 `'true'` / 그 외 false)
- 기본값: 미설정 시 true (기존 동작 유지 — 운영 사고 방지)

## 배경
운영자가 AdMob 정책 위반 등으로 즉시 광고를 내려야 할 때, 클라 빌드 배포를 기다리지 않고 서버 환경변수만으로 끄기 위함.

## 운영
- 광고 OFF: `serverless.yml` 환경변수에 `ADS_ENABLED=false` 추가 후 redeploy
- 추후 DB 기반 feature flag 로 옮기는 것이 정공이지만, 현재 요구사항(1일 1회 정도의 변경 빈도) 에는 환경변수만으로 충분

## Test plan
- [x] tsc --noEmit 통과
- [x] ConfigController 스모크 — false / true / unset / 대소문자 / 빈 문자열 모두 의도대로 동작
- [ ] dev 배포 후 curl /config 응답 확인
- [ ] iOS / Android 클라 분기(MG-132) 가 응답 사용하는지 e2e 확인

클라 측 분기는 별도 PR (iOS MG-132, Android MG-132) 에서 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)