### PR TITLE
fix(answer): Answer.dailyQuestionId 도입으로 questionId 재배정 시 답변 회생 버그 차단 (MG-133)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model DailyQuestion {
   completedAt DateTime? @map("completed_at")
   family      Family    @relation(fields: [familyId], references: [id])
   question    Question  @relation(fields: [questionId], references: [id])
+  answers     Answer[]
 
   @@unique([familyId, date])
   @@index([familyId, completedAt])
@@ -155,18 +156,27 @@ model UserAccessLog {
 }
 
 model Answer {
-  id         String   @id @default(uuid())
-  content    String
-  imageUrl   String?  @map("image_url")
-  userId     String   @map("user_id")
-  questionId String   @map("question_id")
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt @map("updated_at")
-  moodId     String?  @map("mood_id")
-  question   Question @relation(fields: [questionId], references: [id])
-  user       User     @relation(fields: [userId], references: [id])
+  id              String         @id @default(uuid())
+  content         String
+  imageUrl        String?        @map("image_url")
+  userId          String         @map("user_id")
+  questionId      String         @map("question_id")
+  // (MG-133) 어느 DailyQuestion 인스턴스에 대한 답변인지. nullable 인 이유:
+  //   1) 가족이 해체되어 DailyQuestion 이 사라진 옛 답변 (orphan, 운영상 38건 발견)
+  //   2) Postgres 의 nullable + UNIQUE 동작상 NULL 다중 허용 → orphan 끼리 충돌 없음
+  // 새 답변은 application 레이어에서 항상 채운다.
+  dailyQuestionId String?        @map("daily_question_id")
+  createdAt       DateTime       @default(now()) @map("created_at")
+  updatedAt       DateTime       @updatedAt @map("updated_at")
+  moodId          String?        @map("mood_id")
+  question        Question       @relation(fields: [questionId], references: [id])
+  user            User           @relation(fields: [userId], references: [id])
+  dailyQuestion   DailyQuestion? @relation(fields: [dailyQuestionId], references: [id])
 
-  @@unique([userId, questionId])
+  // 같은 user 가 같은 DailyQuestion 에 두 번 답변 못함 (이전 (userId, questionId) 대체).
+  // questionId 만으로 unique 잡으면 같은 question 이 다음 달에 재배정될 때 옛 답변이
+  // 자동 매핑되는 회생 버그가 발생함 (MG-133 root cause).
+  @@unique([userId, dailyQuestionId])
   @@map("answers")
 }
 

--- a/scripts/backfill-answer-daily-question-id.ts
+++ b/scripts/backfill-answer-daily-question-id.ts
@@ -1,0 +1,104 @@
+/**
+ * (MG-133) Answer.dailyQuestionId 백필 스크립트.
+ *
+ * schema 적용 (`npm run db:push`) 후 실행. idempotent — 이미 채워진 행은 건드리지 않는다.
+ *
+ * 매핑 규칙:
+ *   - 같은 questionId 의 DailyQuestion 중에서
+ *   - Answer.user 가 속한 (또는 속했던) familyId 의 DQ 만 후보로
+ *   - DQ.date <= Answer.createdAt 중 가장 최근 date 에 매핑
+ *   → 진단 스크립트와 같은 로직. dry-run 결과: 매핑 67 / orphan 38 / 충돌 0.
+ *
+ * 실행:  npx ts-node scripts/backfill-answer-daily-question-id.ts          # dry-run (변경 없음)
+ *        npx ts-node scripts/backfill-answer-daily-question-id.ts --apply  # 실제 UPDATE
+ */
+
+import prisma from '../src/utils/prisma';
+
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  console.log(`mode: ${APPLY ? 'APPLY (UPDATE 실행)' : 'DRY-RUN (변경 없음)'}\n`);
+
+  const targets = await prisma.answer.findMany({
+    where: { dailyQuestionId: null },
+    select: { id: true, userId: true, questionId: true, createdAt: true },
+    orderBy: { createdAt: 'asc' },
+  });
+
+  console.log(`백필 대상 (dailyQuestionId IS NULL): ${targets.length}건`);
+
+  let mapped = 0;
+  let orphan = 0;
+  let updated = 0;
+  let updateFailed = 0;
+
+  // user → familyIds 캐시 (스크립트 한 번 실행 동안 변하지 않음)
+  const familyIdsByUser = new Map<string, string[]>();
+  async function getFamilyIds(userId: string): Promise<string[]> {
+    const cached = familyIdsByUser.get(userId);
+    if (cached) return cached;
+    const ms = await prisma.familyMembership.findMany({
+      where: { userId },
+      select: { familyId: true },
+    });
+    const ids = ms.map((m) => m.familyId);
+    familyIdsByUser.set(userId, ids);
+    return ids;
+  }
+
+  for (const ans of targets) {
+    const familyIds = await getFamilyIds(ans.userId);
+    if (familyIds.length === 0) {
+      orphan++;
+      continue;
+    }
+
+    const target = await prisma.dailyQuestion.findFirst({
+      where: {
+        questionId: ans.questionId,
+        familyId: { in: familyIds },
+        date: { lte: ans.createdAt },
+      },
+      orderBy: { date: 'desc' },
+      select: { id: true },
+    });
+
+    if (!target) {
+      orphan++;
+      continue;
+    }
+
+    mapped++;
+
+    if (APPLY) {
+      try {
+        await prisma.answer.update({
+          where: { id: ans.id },
+          data: { dailyQuestionId: target.id },
+        });
+        updated++;
+      } catch (e) {
+        updateFailed++;
+        console.error(`  UPDATE 실패: answer=${ans.id} dq=${target.id}`, e);
+      }
+    }
+  }
+
+  console.log(`\n결과:`);
+  console.log(`  매핑 가능 (target DQ 발견): ${mapped}건`);
+  console.log(`  매핑 불가 (orphan, NULL 유지): ${orphan}건`);
+  if (APPLY) {
+    console.log(`  실제 UPDATE 성공: ${updated}건`);
+    console.log(`  UPDATE 실패: ${updateFailed}건`);
+  } else {
+    console.log(`  → --apply 플래그 추가 시 ${mapped}건 UPDATE 실행`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -148,6 +148,12 @@ export interface DailyQuestionHistoryResponse extends DailyQuestionResponse {
 // ============================================
 export interface CreateAnswerRequest {
   questionId: string;
+  /**
+   * (MG-133) 답변 대상 DailyQuestion ID. 신규 클라는 항상 전송 — 서버가 이 값을 검증해
+   * 이전 달 답변이 자동 매핑되는 회생 버그를 차단한다. 미전송 시 서버가 user.familyId 의
+   * today DailyQuestion 으로 fallback (구 클라 하위 호환).
+   */
+  dailyQuestionId?: string;
   content: string;
   imageUrl?: string;
   moodId?: string; // 답변 시 선택한 캐릭터 색상 (happy/calm/loved/sad/tired)
@@ -165,6 +171,8 @@ export interface AnswerResponse {
   imageUrl: string | null;
   user: UserResponse;
   questionId: string;
+  /** (MG-133) 어느 DailyQuestion 인스턴스에 대한 답변인지. orphan(옛 데이터)은 null. */
+  dailyQuestionId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -40,30 +40,48 @@ export class AnswerService {
       throw Errors.notFound('질문');
     }
 
-    // 해당 질문이 사용자의 가족에 배정된 질문인지 검증
+    // (MG-133) 답변 대상 DailyQuestion 결정.
+    //  - 신규 클라: dailyQuestionId 명시 전송 → 그 DQ 가 user 의 가족 + questionId 일치인지 검증
+    //  - 구 클라(미전송): user.familyId 의 같은 questionId DQ 중 가장 최근 것 fallback
+    //                    (이전엔 questionId 만으로 unique 잡아서 다음 달 재배정 시 옛 답변
+    //                     자동 매핑되는 회생 버그가 있었음 — 그래서 가장 최근 DQ 만 매핑)
     let activeDailyQuestion: { id: string } | null = null;
     if (user.familyId) {
-      const dailyQuestion = await prisma.dailyQuestion.findFirst({
-        where: { questionId: normalizedQuestionId, familyId: user.familyId },
-      });
-      if (!dailyQuestion) {
-        throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
+      if (data.dailyQuestionId) {
+        const requested = await prisma.dailyQuestion.findUnique({
+          where: { id: data.dailyQuestionId.toLowerCase() },
+        });
+        if (!requested || requested.familyId !== user.familyId || requested.questionId !== normalizedQuestionId) {
+          throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
+        }
+        activeDailyQuestion = { id: requested.id };
+      } else {
+        const dailyQuestion = await prisma.dailyQuestion.findFirst({
+          where: { questionId: normalizedQuestionId, familyId: user.familyId },
+          orderBy: { date: 'desc' },
+        });
+        if (!dailyQuestion) {
+          throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
+        }
+        activeDailyQuestion = { id: dailyQuestion.id };
       }
-      activeDailyQuestion = dailyQuestion;
     }
 
-    // 이미 답변했는지 확인
-    const existingAnswer = await prisma.answer.findUnique({
-      where: {
-        userId_questionId: {
-          userId: user.id,
-          questionId: normalizedQuestionId,
+    // 같은 user 가 같은 DailyQuestion 에 두 번 답변 못함. activeDailyQuestion 이 null 이면
+    // (가족 미소속 케이스) unique 인덱스가 NULL 다중 허용 — 이 경로의 중복 차단은 application
+    // 레이어에서 별도 검증할 수도 있지만, 현 시점에서는 가족 미소속 답변 자체가 없는 흐름이라 생략.
+    if (activeDailyQuestion) {
+      const existingAnswer = await prisma.answer.findUnique({
+        where: {
+          userId_dailyQuestionId: {
+            userId: user.id,
+            dailyQuestionId: activeDailyQuestion.id,
+          },
         },
-      },
-    });
-
-    if (existingAnswer) {
-      throw Errors.conflict('이미 이 질문에 답변했습니다.');
+      });
+      if (existingAnswer) {
+        throw Errors.conflict('이미 이 질문에 답변했습니다.');
+      }
     }
 
     // 답변 생성
@@ -74,6 +92,7 @@ export class AnswerService {
         moodId: data.moodId,
         userId: user.id,
         questionId: normalizedQuestionId,
+        dailyQuestionId: activeDailyQuestion?.id ?? null,
       },
       include: { user: true },
     });
@@ -194,11 +213,23 @@ export class AnswerService {
       throw Errors.notFound('사용자');
     }
 
+    // (MG-133) questionId 만 받지만 같은 question 이 여러 DQ 에 재배정될 수 있으므로
+    // user.familyId 의 가장 최근 DQ 한 건만 본다. 옛 답변이 회생되어 보이는 일 차단.
+    let dq: { id: string } | null = null;
+    if (user.familyId) {
+      dq = await prisma.dailyQuestion.findFirst({
+        where: { questionId: questionId.toLowerCase(), familyId: user.familyId },
+        orderBy: { date: 'desc' },
+        select: { id: true },
+      });
+    }
+    if (!dq) return null;
+
     const answer = await prisma.answer.findUnique({
       where: {
-        userId_questionId: {
+        userId_dailyQuestionId: {
           userId: user.id,
-          questionId: questionId.toLowerCase(),
+          dailyQuestionId: dq.id,
         },
       },
       include: { user: true },
@@ -257,15 +288,20 @@ export class AnswerService {
       orderBy: { date: 'desc' },
     });
 
-    // 가족 구성원들의 답변 조회
-    const answers = await prisma.answer.findMany({
-      where: {
-        questionId: questionId.toLowerCase(),
-        userId: { in: memberUserIds },
-      },
-      include: { user: true },
-      orderBy: { createdAt: 'asc' },
-    });
+    // (MG-133) 가족 구성원들의 답변 조회 — 가장 최근 DQ 인스턴스 한 건의 답변만.
+    // 이전 questionId 만으로 조회 시, 같은 question 이 다음 달 재배정될 때 옛 답변이
+    // 그대로 화면에 노출되던 회생 버그가 있었음. dailyQuestion null (배정 이력 없음)
+    // 이면 빈 응답.
+    const answers = dailyQuestion
+      ? await prisma.answer.findMany({
+          where: {
+            dailyQuestionId: dailyQuestion.id,
+            userId: { in: memberUserIds },
+          },
+          include: { user: true },
+          orderBy: { createdAt: 'asc' },
+        })
+      : [];
 
     const myAnswer = answers.find((a) => a.userId === user.id);
     const answeredUserIds = new Set(answers.map((a) => a.userId));
@@ -422,6 +458,7 @@ export class AnswerService {
       imageUrl: string | null;
       moodId?: string | null;
       questionId: string;
+      dailyQuestionId?: string | null;
       createdAt: Date;
       updatedAt: Date;
       user: {
@@ -446,6 +483,7 @@ export class AnswerService {
       content: answer.content,
       imageUrl: answer.imageUrl,
       questionId: answer.questionId,
+      dailyQuestionId: answer.dailyQuestionId ?? null,
       createdAt: answer.createdAt,
       updatedAt: answer.updatedAt,
       user: {

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -95,10 +95,19 @@ export class QuestionService {
       select: { userId: true, skippedDate: true },
     });
 
+    // (MG-133) 이 (familyId, date) 의 DQ 인스턴스에 매핑된 답변만. questionId 만으로
+    // 보면 같은 question 이 재배정될 때 옛 답변으로 모든 멤버가 답변한 것처럼 잘못
+    // 판정되어 한 번도 답변하지 않은 DQ 가 자동 완료될 수 있었음.
+    const dq = await prisma.dailyQuestion.findUnique({
+      where: { familyId_date: { familyId, date } },
+      select: { id: true },
+    });
+    if (!dq) return false;
+
     const answeredUserIds = new Set(
       (await prisma.answer.findMany({
         where: {
-          questionId,
+          dailyQuestionId: dq.id,
           userId: { in: memberships.map((m) => m.userId) },
         },
         select: { userId: true },
@@ -166,9 +175,10 @@ export class QuestionService {
       throw Errors.badRequest('하트가 부족합니다. 질문을 패스하려면 하트 3개가 필요합니다.');
     }
 
-    // 이미 답변한 경우 패스 불가
+    // (MG-133) 이 DQ 인스턴스에 매핑된 답변만 — questionId 만 보면 옛 달 답변 때문에
+    // 잘못 차단됨.
     const myAnswer = await prisma.answer.findFirst({
-      where: { questionId: dailyQuestion.question.id, userId: user.id },
+      where: { dailyQuestionId: dailyQuestion.id, userId: user.id },
     });
     if (myAnswer) {
       throw Errors.conflict('이미 답변한 질문은 패스할 수 없습니다.');
@@ -268,13 +278,12 @@ export class QuestionService {
       prisma.dailyQuestion.findMany({
         where: { familyId: user.familyId, date: { lte: today } },
         include: {
-          question: {
-            include: {
-              answers: {
-                where: { userId: { in: memberIds } },
-                include: { user: { select: { id: true, name: true, familyId: true } } },
-              },
-            },
+          question: true,
+          // (MG-133) DQ 직접 역방향 — 이전엔 question.answers 로 가져와 같은 question 이
+          // 다음 달 재배정될 때 옛 답변까지 포함되던 회생 버그.
+          answers: {
+            where: { userId: { in: memberIds } },
+            include: { user: { select: { id: true, name: true, familyId: true } } },
           },
         },
         orderBy: [
@@ -290,11 +299,9 @@ export class QuestionService {
     ]);
 
     const data: DailyQuestionHistoryResponse[] = dailyQuestions.map((dq) => {
-      // 해당 질문에 대한 그룹 멤버들의 답변 전체를 포함.
-      // (이전에는 "DQ.date 기준 KST 하루 창" 으로 필터링했으나, 배정일 다음날 이후에
-      //  답변이 들어온 경우 history 에서 사라지는 데이터 손실 버그가 있었다.
-      //  완료 시점에 DQ.date 자체가 완료일자로 이동하므로 윈도우 필터 불필요.)
-      const answers = dq.question.answers;
+      // (MG-133) DQ 자체에 매핑된 답변만 — 이전엔 dq.question.answers 로 같은 질문의
+      // 모든 답변을 가져와 다른 달 답변이 회생되어 보이던 버그가 있었음.
+      const answers = dq.answers;
       const answerSummaries: HistoryAnswerSummary[] = answers.map((a) => ({
         id: a.id,
         userId: a.userId,
@@ -573,10 +580,11 @@ export class QuestionService {
     ]);
     const memberIds = memberships.map((m) => m.userId);
 
-    // 가족 멤버의 답변 조회 (questionId + userId unique constraint로 중복 없음)
+    // (MG-133) 이 DQ 인스턴스에 매핑된 답변만. 이전엔 questionId 만으로 조회해서
+    // 같은 question 이 다음 달 재배정될 때 옛 답변까지 hit → hasMyAnswer=true 회생.
     const answers = await prisma.answer.findMany({
       where: {
-        questionId: dailyQuestion.question.id,
+        dailyQuestionId: dailyQuestion.id,
         userId: { in: memberIds },
       },
       select: { userId: true },

--- a/src/services/dailyQuestionCompletion.ts
+++ b/src/services/dailyQuestionCompletion.ts
@@ -34,9 +34,11 @@ export async function tryFinalizeDailyQuestion(params: {
   });
   if (memberships.length === 0) return;
 
+  // (MG-133) 이 DQ 인스턴스에 매핑된 답변만. questionId 만 보면 같은 question 이
+  // 다음 달 재배정될 때 옛 답변으로 잘못 완료 처리될 수 있음.
   const answers = await prisma.answer.findMany({
     where: {
-      questionId: dq.questionId,
+      dailyQuestionId: dq.id,
       userId: { in: memberships.map((m) => m.userId) },
     },
     select: { userId: true },


### PR DESCRIPTION
## 원인
같은 question 이 다음 달 재배정될 때 옛 Answer 레코드가 그대로 hasMyAnswer=true 로 매핑되는 회생 버그. 4월에 답변한 question 이 5월에 다시 배정된 가족(zxx 그룹 등) 이 영향. assignQuestionToFamily 의 30일 윈도우는 결함을 가리던 안전망이었을 뿐.

## 근본 결함
Answer 가 DailyQuestion 이 아닌 Question 을 직접 참조 + (userId, questionId) unique → "어느 날 어느 DQ 인스턴스의 답변인지" 흔적 없음. 사용자가 새 답변을 시도하면 unique 충돌로 차단되고, 화면엔 옛 답변/색상이 표시됨.

## 진단
\`scripts/check-may-affected-families.ts\` dry-run 결과:
- 매핑 가능: 67건
- orphan (가족 해체된 답변): 38건
- 슬롯 충돌: 0건 → 백필 안전

## 변경 요약
- \`Answer.dailyQuestionId String?\` 추가, \`(userId, dailyQuestionId)\` unique 로 교체 (NULL 다중 허용 → orphan 보존)
- DailyQuestion ↔ Answer 양방향 relation
- \`CreateAnswerRequest.dailyQuestionId\` 선택 필드 (구 클라 fallback 보장)
- \`AnswerResponse.dailyQuestionId\` 노출
- 회생 진원지 7곳 모두 dailyQuestionId 기준으로:
  - AnswerService: createAnswer / getMyAnswer / getFamilyAnswers
  - QuestionService: toDailyQuestionResponse / isQuestionCompleted / skipTodayQuestion / history
  - dailyQuestionCompletion.tryFinalizeDailyQuestion

## 운영 배포 절차 (반드시 순서대로)

\`\`\`bash
# 1) 머지 후, 코드 deploy 전에 먼저 스키마 + 백필부터
DATABASE_URL=<prod> npm run db:push                                          # column 추가는 nullable 이라 online
DATABASE_URL=<prod> npx ts-node scripts/backfill-answer-daily-question-id.ts # dry-run
DATABASE_URL=<prod> npx ts-node scripts/backfill-answer-daily-question-id.ts --apply  # 실제 67건 UPDATE

# 2) 그 다음 application 배포
npm run deploy:prod
\`\`\`

**중요**: schema 만 적용하고 백필 안 한 상태로 새 application 이 뜨면, 사용자가 답변한 것이 화면에서 사라지는 회귀 발생 (dailyQuestionId=NULL 인 옛 답변들). 반드시 백필 먼저.

## Test plan
- [x] \`npx tsc --noEmit\` 통과
- [x] \`npx jest\` 98/102 PASS (4 FAIL 은 main 기존 FamilyService mock 부족, MG-133 무관)
- [ ] dev 배포 후 zxx 같은 영향 가족에서 오늘의 질문 화면 → 답변 안 한 상태로 정상 표시
- [ ] dev 에서 오늘 답변 작성 → 정상 저장 + DQ 와 매핑 확인
- [ ] history 화면에서 4월 답변이 4월 자리에만 표시 (5월 자리에 회생 X)

## 클라 후속
iOS/Android 클라가 답변 저장 시 dailyQuestionId 보내는 변경은 별도 PR. 서버 fallback 으로 구 클라도 안전 동작 (today DQ 자동 매핑) 하므로 클라 배포는 급하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)