### PR TITLE
fix(answer): 활성 그룹 없을 때 답변 거부 — dailyQuestionId NULL orphan 차단 (MG-131)

### DIFF
--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -40,6 +40,13 @@ export class AnswerService {
       throw Errors.notFound('질문');
     }
 
+    // (MG-131) 활성 그룹 없으면 답변을 받지 않는다. user.familyId 가 null 인데 답변을
+    // 저장하면 dailyQuestionId 가 NULL 인 orphan 으로 들어가, 이후 홈/기록 API 의
+    // (dailyQuestionId, userId) 쿼리에 매치되지 않아 UI 에서 영영 누락된다 (5/17 발생 사례).
+    if (!user.familyId) {
+      throw Errors.badRequest('활성 그룹이 없습니다. 그룹 가입 후 답변해주세요.');
+    }
+
     // (MG-133) 답변 대상 DailyQuestion 결정.
     //  - 신규 클라: dailyQuestionId 명시 전송 → 그 DQ 가 user 의 가족 + questionId 일치인지 검증
     //  - 구 클라(미전송): user.familyId 의 같은 questionId DQ 중 가장 최근 것 fallback


### PR DESCRIPTION
## Summary
- 활성 그룹(`user.familyId`) 없는 상태로 답변이 들어오면 `Answer.dailyQuestionId` 가 NULL 인 채로 저장되어, 홈/기록 API 의 `(dailyQuestionId, userId)` 쿼리에 매치되지 않아 UI 에서 영영 누락되는 회귀.
- 5/13 백필 이후 발생한 NULL orphan 1건(2026-05-17 1정3최 그룹 '써니' 답변)이 [MG-130](https://ycompany.atlassian.net/browse/MG-130) 의 진짜 root cause.
- `AnswerService.createAnswer()` 의 `activeDailyQuestion` 결정 전 `!user.familyId` 명시 차단 + `Errors.badRequest`.

## 가설 정정
- 가설 1 (클라 캐시 누락, iOS PR #128 · Android PR #71) — 회귀 보강책으로 유효하나 root cause 아님
- 가설 2 (`isSameDate` UTC vs KST) — 답변 시각이 KST 16:46 으로 0~8시 윈도우 무관, 제외 확정
- **가설 3 (본 PR)** — `user.familyId === null` 가드 누락이 진짜 원인

## 백필 결과 (prod)
`scripts/backfill-answer-daily-question-id.ts --apply` 실행:
- 매핑 가능 1건 → UPDATE 성공
- 매핑 불가 38건 (가족 해체로 인한 orphan, NULL 유지)

## Test plan
- [ ] `user.familyId` 가 null 인 사용자가 `POST /answers` 호출 시 400 응답 + 한국어 안내
- [ ] 정상 사용자(`user.familyId` 채워진)는 기존대로 답변 저장 + `dailyQuestionId` 채워짐
- [ ] 백필된 답변(`02b4d1f8-...`) 이 홈/기록 응답에 정상 노출되는지 시뮬레이터로 확인