### PR TITLE
fix(config): serverless에 ADS_ENABLED 배선 추가 — 광고 OFF 실제 반영 (MG-137)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,11 @@ provider:
     SMTP_USER: ${env:SMTP_USER, ''}
     SMTP_PASS: ${env:SMTP_PASS, ''}
     SMTP_FROM: ${env:SMTP_FROM, ''}
+    # 광고 노출 토글 (MG-137). ConfigController(/config)가 이 값을 그대로 isAdEnabled 로
+    # 반환한다. 이 줄이 없으면 Lambda 런타임에 ADS_ENABLED 가 주입되지 않아 항상 undefined →
+    # 컨트롤러가 기본 true 로 응답해 운영자가 무엇을 설정해도 광고가 꺼지지 않는다.
+    # 미설정 시 'true'(기존 동작). OFF 하려면 .env 에 ADS_ENABLED=false.
+    ADS_ENABLED: ${env:ADS_ENABLED, 'true'}
 
   # IAM 권한 (최소 권한 원칙)
   iam:


### PR DESCRIPTION
## 배경
운영자가 광고를 OFF 로 설정해도 앱에 광고가 계속 노출됨. prod `/config` 를 직접 호출하면 `{"isAdEnabled":true}` 가 반환됨(실측).

## 원인
- `/config`(MG-131)는 `process.env.ADS_ENABLED` 를 읽어 `isAdEnabled` 를 반환하도록 구현됨.
- 그러나 `serverless.yml` 의 `provider.environment` 에 `ADS_ENABLED` 가 없어 배포된 Lambda 런타임에서 항상 `undefined`.
- 컨트롤러 로직상 `undefined` → 기본 `true`. 즉 운영자가 무엇을 설정해도 광고가 꺼질 수 없는 구조였음.

## 변경
- `provider.environment` 에 `ADS_ENABLED: ${env:ADS_ENABLED, 'true'}` 추가.
- 실제 OFF 는 prod `.env` 에 `ADS_ENABLED=false` 설정(이 PR에 미포함 — .env는 gitignore).

## 배포 절차 (머지 후)
1. prod `.env` 에 `ADS_ENABLED=false` 확인
2. `npm run build && npm run deploy:prod` (build 누락 시 tsoa routes 함정 주의)
3. `curl https://15i45fprse.execute-api.ap-northeast-2.amazonaws.com/config` → `{"isAdEnabled":false}` 확인
4. 앱은 다음 부팅부터 배너 숨김(AdConfigStore 캐시 갱신)

## 참고 — "Test Mode 광고"는 별개 이슈
DEBUG 빌드에서 Google 테스트 광고 단위 ID(`ca-app-pub-3940256099942544/...`)를 쓰기 때문이며 정상 동작. 실 광고는 Release/App Store 빌드에서만 노출됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)