### PR TITLE
fix(answer): createAnswer를 FamilyMembership 기준으로 — 멀티그룹 답변 누락 차단 (MG-138)

### DIFF
--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -40,55 +40,64 @@ export class AnswerService {
       throw Errors.notFound('질문');
     }
 
-    // (MG-131) 활성 그룹 없으면 답변을 받지 않는다. user.familyId 가 null 인데 답변을
-    // 저장하면 dailyQuestionId 가 NULL 인 orphan 으로 들어가, 이후 홈/기록 API 의
-    // (dailyQuestionId, userId) 쿼리에 매치되지 않아 UI 에서 영영 누락된다 (5/17 발생 사례).
-    if (!user.familyId) {
+    // (MG-138) 답변 대상 그룹은 user.familyId(단일 "활성" 그룹)가 아니라 사용자의 모든
+    // FamilyMembership 기준으로 정한다. user.familyId 는 현재 활성 가족 1개만 가리키므로,
+    // 멀티그룹 멤버가 비활성 그룹의 질문에 답하면 옛 코드는 해당 DQ 를 그 그룹에서 못 찾아
+    // 답변을 거부했다(400) — 5/18 써니 사례. 읽기 경로 getFamilyAnswers 가 이미 멤버십
+    // 기반인 것과 일치시킨다.
+    const memberships = await prisma.familyMembership.findMany({
+      where: { userId: user.id },
+      select: { familyId: true },
+    });
+    const familyIds = memberships.map((m) => m.familyId);
+
+    // 그룹 미소속이면 답변을 받지 않는다 (MG-131). 소속 없이 저장하면 dailyQuestionId 가
+    // NULL orphan 으로 들어가 이후 홈/기록 API 의 (dailyQuestionId, userId) 쿼리에 영영
+    // 매치되지 않아 UI 에서 누락된다.
+    if (familyIds.length === 0) {
       throw Errors.badRequest('활성 그룹이 없습니다. 그룹 가입 후 답변해주세요.');
     }
 
-    // (MG-133) 답변 대상 DailyQuestion 결정.
-    //  - 신규 클라: dailyQuestionId 명시 전송 → 그 DQ 가 user 의 가족 + questionId 일치인지 검증
-    //  - 구 클라(미전송): user.familyId 의 같은 questionId DQ 중 가장 최근 것 fallback
-    //                    (이전엔 questionId 만으로 unique 잡아서 다음 달 재배정 시 옛 답변
-    //                     자동 매핑되는 회생 버그가 있었음 — 그래서 가장 최근 DQ 만 매핑)
-    let activeDailyQuestion: { id: string } | null = null;
-    if (user.familyId) {
-      if (data.dailyQuestionId) {
-        const requested = await prisma.dailyQuestion.findUnique({
-          where: { id: data.dailyQuestionId.toLowerCase() },
-        });
-        if (!requested || requested.familyId !== user.familyId || requested.questionId !== normalizedQuestionId) {
-          throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
-        }
-        activeDailyQuestion = { id: requested.id };
-      } else {
-        const dailyQuestion = await prisma.dailyQuestion.findFirst({
-          where: { questionId: normalizedQuestionId, familyId: user.familyId },
-          orderBy: { date: 'desc' },
-        });
-        if (!dailyQuestion) {
-          throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
-        }
-        activeDailyQuestion = { id: dailyQuestion.id };
+    // (MG-133/138) 답변 대상 DailyQuestion 결정.
+    //  - 신규 클라: dailyQuestionId 명시 전송 → 그 DQ 가 user 의 가족(들) + questionId 일치인지 검증
+    //  - 구 클라(미전송): 사용자의 가족들 중 같은 questionId DQ 가장 최근 것 fallback.
+    //    (같은 question 이 여러 그룹에 배정된 멀티그룹 케이스는 클라가 dailyQuestionId 를
+    //     보내야 정확히 특정된다 — 클라 후속 작업. 그 전까지는 best-effort 로 최근 DQ.)
+    let activeDailyQuestion: { id: string; familyId: string };
+    if (data.dailyQuestionId) {
+      const requested = await prisma.dailyQuestion.findUnique({
+        where: { id: data.dailyQuestionId.toLowerCase() },
+      });
+      if (!requested || !familyIds.includes(requested.familyId) || requested.questionId !== normalizedQuestionId) {
+        throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
       }
+      activeDailyQuestion = { id: requested.id, familyId: requested.familyId };
+    } else {
+      const dailyQuestion = await prisma.dailyQuestion.findFirst({
+        where: { questionId: normalizedQuestionId, familyId: { in: familyIds } },
+        orderBy: { date: 'desc' },
+      });
+      if (!dailyQuestion) {
+        throw Errors.badRequest('이 질문은 그룹에 배정되지 않았습니다.');
+      }
+      activeDailyQuestion = { id: dailyQuestion.id, familyId: dailyQuestion.familyId };
     }
 
-    // 같은 user 가 같은 DailyQuestion 에 두 번 답변 못함. activeDailyQuestion 이 null 이면
-    // (가족 미소속 케이스) unique 인덱스가 NULL 다중 허용 — 이 경로의 중복 차단은 application
-    // 레이어에서 별도 검증할 수도 있지만, 현 시점에서는 가족 미소속 답변 자체가 없는 흐름이라 생략.
-    if (activeDailyQuestion) {
-      const existingAnswer = await prisma.answer.findUnique({
-        where: {
-          userId_dailyQuestionId: {
-            userId: user.id,
-            dailyQuestionId: activeDailyQuestion.id,
-          },
+    // 답변이 실제로 속한 그룹. 하트/알림/완료처리 등 부수효과는 user.familyId 가 아니라
+    // 이 값을 기준으로 한다 (비활성 그룹 질문 답변도 올바른 그룹에 반영되도록).
+    const answerFamilyId = activeDailyQuestion.familyId;
+
+    // 같은 user 가 같은 DailyQuestion 에 두 번 답변 못함.
+    const existingAnswer = await prisma.answer.findUnique({
+      where: {
+        userId_dailyQuestionId: {
+          userId: user.id,
+          dailyQuestionId: activeDailyQuestion.id,
         },
-      });
-      if (existingAnswer) {
-        throw Errors.conflict('이미 이 질문에 답변했습니다.');
-      }
+      },
+    });
+    if (existingAnswer) {
+      throw Errors.conflict('이미 이 질문에 답변했습니다.');
     }
 
     // 답변 생성
@@ -99,15 +108,15 @@ export class AnswerService {
         moodId: data.moodId,
         userId: user.id,
         questionId: normalizedQuestionId,
-        dailyQuestionId: activeDailyQuestion?.id ?? null,
+        dailyQuestionId: activeDailyQuestion.id,
       },
       include: { user: true },
     });
 
-    // 하트 +1, 답변 시 선택한 캐릭터 색상(moodId) 저장 (FamilyMembership 기준)
-    if (user.familyId) {
+    // 하트 +1, 답변 시 선택한 캐릭터 색상(moodId) 저장 (답변이 속한 그룹의 FamilyMembership 기준)
+    if (answerFamilyId) {
       await prisma.familyMembership.updateMany({
-        where: { userId: user.id, familyId: user.familyId },
+        where: { userId: user.id, familyId: answerFamilyId },
         data: {
           hearts: { increment: 1 },
           ...(data.moodId && { colorId: data.moodId }),
@@ -116,7 +125,7 @@ export class AnswerService {
 
       // 가족 멤버(본인 제외)에게 답변 알림 발송
       const senderMembership = await prisma.familyMembership.findUnique({
-        where: { userId_familyId: { userId: user.id, familyId: user.familyId } },
+        where: { userId_familyId: { userId: user.id, familyId: answerFamilyId } },
         select: { nickname: true, colorId: true },
       });
       const senderNickname = senderMembership?.nickname ?? user.name;
@@ -126,7 +135,7 @@ export class AnswerService {
       // 멤버가 다른 그룹을 활성으로 두면 매칭 0건이 되어 MEMBER_ANSWERED 알림이 누락되던
       // 버그(MG-29) 수정. 본인 제외는 userId 비교로 처리.
       const otherMemberships = await prisma.familyMembership.findMany({
-        where: { familyId: user.familyId, userId: { not: user.id } },
+        where: { familyId: answerFamilyId, userId: { not: user.id } },
         select: {
           user: {
             select: {
@@ -151,7 +160,7 @@ export class AnswerService {
         const title = msgs.memberAnswered.title(senderNickname);
         const body = msgs.memberAnswered.body;
         dbNotifTasks.push(
-          notificationService.createNotification(member.id, 'MEMBER_ANSWERED', title, body, user.familyId, senderColorId)
+          notificationService.createNotification(member.id, 'MEMBER_ANSWERED', title, body, answerFamilyId, senderColorId)
             .then((notifId) => { notificationIdByMember.set(member.id, notifId); })
             .catch((e) => {
               console.warn('[Answer] 알림 저장 실패:', e);
@@ -196,15 +205,13 @@ export class AnswerService {
 
       // 그룹 전원이 이번 답변으로 완료되었다면 DailyQuestion.completedAt 을 기록
       // → history 상 "완료일자" 기준으로 노출 (20일 배정 + 21일 완료 → 21일에 기록)
-      if (activeDailyQuestion) {
-        try {
-          await tryFinalizeDailyQuestion({
-            familyId: user.familyId,
-            dailyQuestionId: activeDailyQuestion.id,
-          });
-        } catch (e) {
-          console.warn('[Answer] DQ finalize 실패:', e);
-        }
+      try {
+        await tryFinalizeDailyQuestion({
+          familyId: answerFamilyId,
+          dailyQuestionId: activeDailyQuestion.id,
+        });
+      } catch (e) {
+        console.warn('[Answer] DQ finalize 실패:', e);
       }
     }
 

--- a/src/services/__tests__/AnswerService.test.ts
+++ b/src/services/__tests__/AnswerService.test.ts
@@ -118,10 +118,14 @@ const mockAnswerWithUser = {
 
 // createAnswer 가 성공 경로로 흘러갈 때 필요한 후속 호출들을 미리 세팅
 function setupCreateAnswerSuccessPath() {
-  mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id' });
+  // (MG-138) familyMembership.findMany 는 두 번 호출된다:
+  //   1) getFamilyIds — 사용자의 소속 그룹 목록 (답변 대상 DQ 해석 기준)
+  //   2) otherMemberships — 답변 그룹의 타 멤버 (빈 배열 = 알림/푸시 루프 생략)
+  mockPrismaFamilyMembershipFindMany
+    .mockResolvedValueOnce([{ familyId: 'family-id' }])
+    .mockResolvedValueOnce([]);
+  mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id', familyId: 'family-id' });
   mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ nickname: null, colorId: 'loved' });
-  // MG-29: prisma.user.findMany → familyMembership.findMany 로 변경됨. 빈 멤버십 = 알림/푸시 루프 생략.
-  mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([]);
 }
 
 describe('AnswerService.createAnswer', () => {
@@ -143,7 +147,8 @@ describe('AnswerService.createAnswer', () => {
   it('이미 답변한 질문에 다시 답변하면 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaQuestionFindUnique.mockResolvedValue(mockQuestion);
-    mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id' });
+    mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([{ familyId: 'family-id' }]); // getFamilyIds
+    mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-id', familyId: 'family-id' });
     mockPrismaAnswerFindUnique.mockResolvedValue(mockAnswerWithUser); // 이미 답변 존재
 
     await expect(
@@ -168,16 +173,47 @@ describe('AnswerService.createAnswer', () => {
     );
   });
 
-  it('가족이 없는 유저는 하트 업데이트를 하지 않는다', async () => {
-    const userNoFamily = { ...mockUser, familyId: null };
-    mockPrismaUserFindUnique.mockResolvedValue(userNoFamily);
+  it('소속 그룹이 없는 유저는 답변이 거부된다 (MG-138 — 멤버십 기준)', async () => {
+    // user.familyId 가 null 이든 아니든, 판단 기준은 FamilyMembership 집합이다.
+    mockPrismaUserFindUnique.mockResolvedValue(mockUser);
+    mockPrismaQuestionFindUnique.mockResolvedValue(mockQuestion);
+    mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([]); // 멤버십 0건
+
+    await expect(
+      service.createAnswer('kakao:123', { questionId: 'question-id', content: '답변' })
+    ).rejects.toThrow('활성 그룹이 없습니다');
+    expect(mockPrismaFamilyMembershipUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('비활성 그룹(user.familyId 와 다른 멤버십)의 질문에도 답변이 저장된다 (MG-138)', async () => {
+    // user.familyId 는 'family-id' 지만, 실제 답변 대상 DQ 는 다른 소속 그룹 'other-fam' 의 것.
+    mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaQuestionFindUnique.mockResolvedValue(mockQuestion);
     mockPrismaAnswerFindUnique.mockResolvedValue(null);
     mockPrismaAnswerCreate.mockResolvedValue(mockAnswerWithUser);
+    mockPrismaFamilyMembershipUpdateMany.mockResolvedValue({ count: 1 });
+    mockPrismaFamilyMembershipFindMany
+      .mockResolvedValueOnce([{ familyId: 'family-id' }, { familyId: 'other-fam' }]) // getFamilyIds
+      .mockResolvedValueOnce([]); // otherMemberships
+    // fallback 이 사용자의 그룹들 중 최근 DQ 로 'other-fam' 을 고른 상황
+    mockPrismaDailyQuestionFindFirst.mockResolvedValue({ id: 'daily-q-other', familyId: 'other-fam' });
+    mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ nickname: null, colorId: 'loved' });
 
     await service.createAnswer('kakao:123', { questionId: 'question-id', content: '답변' });
 
-    expect(mockPrismaFamilyMembershipUpdateMany).not.toHaveBeenCalled();
+    // 답변 생성 시 그 DQ 에 연결
+    expect(mockPrismaAnswerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ dailyQuestionId: 'daily-q-other' }),
+      })
+    );
+    // 하트는 답변이 속한 그룹(other-fam) 에 +1
+    expect(mockPrismaFamilyMembershipUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ familyId: 'other-fam' }),
+        data: expect.objectContaining({ hearts: { increment: 1 } }),
+      })
+    );
   });
 
   it('questionId는 소문자로 정규화된다', async () => {


### PR DESCRIPTION
## 배경
멀티그룹 사용자가 '현재 활성 그룹이 아닌' 그룹의 질문에 답하면 답변이 저장되지 않음(서버 400). 실제 사례: 1정3최 5/18 질문에 써니(써니써니+1정3최 멤버)의 답변이 서버에 전혀 없음 — 써니의 서버 활성 그룹이 휴면 그룹 "써니써니"였고, 서버가 그 그룹에서 해당 DQ를 못 찾아 거부.

## 원인
`AnswerService.createAnswer`가 답변 대상 DailyQuestion을 `user.familyId`(단일 "활성" 그룹) 기준으로 해석/검증:
- 명시 전송 시 `requested.familyId !== user.familyId` 면 거부
- 미전송 시 `findFirst({ questionId, familyId: user.familyId })`

읽기 경로 `getFamilyAnswers`는 이미 `FamilyMembership` 집합 기반으로 고쳤으나(코드 주석도 "user.familyId는 다대다 전환 후 부정확"이라 명시), **쓰기 경로는 미반영**이었음.

## 변경
- DQ 해석/검증을 사용자의 **`FamilyMembership` 집합**(`familyId in [...]`) 기준으로.
- 부수효과(하트 +1, MEMBER_ANSWERED 알림, DQ 완료처리)를 `user.familyId`가 아니라 **답변이 실제 속한 DQ의 `familyId`(`answerFamilyId`)** 기준으로 → 비활성 그룹 답변도 올바른 그룹에 반영.
- 그룹 미소속 가드를 `user.familyId == null` → **멤버십 0건**으로 일반화.

## 테스트
- 기존 stale 케이스("가족 없음=성공 가정", #67 이후 이미 red였음) 정정.
- 멀티그룹 비활성 그룹 저장 + 하트가 올바른 그룹에 적립되는 테스트 추가.
- `AnswerService` 22/22 통과, `npm run build`(tsoa+tsc) 통과. (FamilyService 테스트 실패는 이 브랜치 이전부터 존재하는 별개 이슈)

## 후속 (별도 이슈 예정)
- iOS/Android: create 시 실제 `dailyQuestionId` 전송(같은 질문이 여러 그룹에 배정된 경우 정확 특정).
- Android: 제출 실패 시 드래프트 보존/재시도(답변 소실 방지).

## 참고
- 이미 발생한 1건(호 5/24 orphan)은 백필로 복구 완료. 써니 5/18 답변은 서버에 데이터가 없어 복구 불가 → 재답변 필요.
- 이 가드는 #67(MG-131)을 포함/대체하므로, 배포되면 NULL orphan 생성도 함께 차단됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)