### PR TITLE
feat(push): 디바이스 토큰을 세션에서 분리(소프트 로그아웃) — 로그아웃 상태 푸시 누락 차단 (MG-141)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
@@ -9,48 +9,55 @@ datasource db {
 }
 
 model User {
-  id                 String             @id @default(uuid())
-  userId             String             @unique @map("user_id")
-  email              String             @unique
-  name               String
-  profileImageUrl    String?            @map("profile_image_url")
-  role               UserRole           @default(OTHER)
-  hearts             Int                @default(0)
-  lastHeartGrantedAt DateTime?          @map("last_heart_granted_at")
-  familyId           String?            @map("family_id")
-  createdAt          DateTime           @default(now()) @map("created_at")
-  updatedAt          DateTime           @updatedAt @map("updated_at")
-  moodId             String?            @default("loved") @map("mood_id")
-  apnsToken          String?            @map("apns_token")
+  id                     String             @id @default(uuid())
+  userId                 String             @unique @map("user_id")
+  email                  String             @unique
+  name                   String
+  profileImageUrl        String?            @map("profile_image_url")
+  role                   UserRole           @default(OTHER)
+  hearts                 Int                @default(0)
+  lastHeartGrantedAt     DateTime?          @map("last_heart_granted_at")
+  familyId               String?            @map("family_id")
+  createdAt              DateTime           @default(now()) @map("created_at")
+  updatedAt              DateTime           @updatedAt @map("updated_at")
+  moodId                 String?            @default("loved") @map("mood_id")
+  apnsToken              String?            @map("apns_token")
   // iOS 빌드 환경에 따른 APNs 호스트 선택용. Debug 빌드는 sandbox, TestFlight/Store는 production.
   // 토큰 등록 API에서 클라이언트가 함께 전달하며, 기존 레코드는 v1 배포 유저라 production default.
-  apnsEnvironment    ApnsEnvironment?   @default(production) @map("apns_environment")
-  fcmToken           String?            @map("fcm_token")
+  apnsEnvironment        ApnsEnvironment?   @default(production) @map("apns_environment")
+  fcmToken               String?            @map("fcm_token")
   // Accept-Language 기반 사용자 선호 언어 (ko/en/ja). 서버가 푸시 알림 문구를 다국어로 선택할 때 사용.
-  locale             String?            @map("locale")
+  locale                 String?            @map("locale")
   // 약관/개인정보 동의 버전 — Legal/ 폴더 문서 개정 시 LEGAL_VERSIONS 상수 갱신.
   // 사용자 동의 버전이 현재 버전과 다르면 클라이언트에 needsConsent=true 반환.
-  termsAcceptedVersion   String?   @map("terms_accepted_version")
-  termsAcceptedAt        DateTime? @map("terms_accepted_at")
-  privacyAcceptedVersion String?   @map("privacy_accepted_version")
-  privacyAcceptedAt      DateTime? @map("privacy_accepted_at")
+  termsAcceptedVersion   String?            @map("terms_accepted_version")
+  termsAcceptedAt        DateTime?          @map("terms_accepted_at")
+  privacyAcceptedVersion String?            @map("privacy_accepted_version")
+  privacyAcceptedAt      DateTime?          @map("privacy_accepted_at")
   // 알림 선호도 — 각 타입별 ON/OFF. 기본값 true(수신)
-  notifAnswer            Boolean   @default(true)  @map("notif_answer")    // 구성원 답변 알림
-  notifNudge             Boolean   @default(true)  @map("notif_nudge")     // 재촉하기 알림
-  notifQuestion          Boolean   @default(true)  @map("notif_question")  // 새 질문 알림
-  notifAnswererNudge     Boolean   @default(true)  @map("notif_answerer_nudge") // 내가 답변 후 가족 미답변 알림
-  quietHoursEnabled      Boolean   @default(true)  @map("quiet_hours_enabled")
-  quietHoursStart        String    @default("22:00") @map("quiet_hours_start")
-  quietHoursEnd          String    @default("08:00") @map("quiet_hours_end")
+  notifAnswer            Boolean            @default(true) @map("notif_answer") // 구성원 답변 알림
+  notifNudge             Boolean            @default(true) @map("notif_nudge") // 재촉하기 알림
+  notifQuestion          Boolean            @default(true) @map("notif_question") // 새 질문 알림
+  notifAnswererNudge     Boolean            @default(true) @map("notif_answerer_nudge") // 내가 답변 후 가족 미답변 알림
+  quietHoursEnabled      Boolean            @default(true) @map("quiet_hours_enabled")
+  quietHoursStart        String             @default("22:00") @map("quiet_hours_start")
+  quietHoursEnd          String             @default("08:00") @map("quiet_hours_end")
   // 이메일/비밀번호 로그인용 bcrypt 해시. 소셜 전용 계정이면 NULL.
-  passwordHash           String?   @map("password_hash")
-  answers            Answer[]
-  memberships        FamilyMembership[]
-  moodRecords        MoodRecord[]
-  notifications      Notification[]
-  accessLogs         UserAccessLog[]
-  refreshTokens      UserRefreshToken[]
-  family             Family?            @relation(fields: [familyId], references: [id])
+  passwordHash           String?            @map("password_hash")
+  // (MG-141) 푸시 토큰 ↔ 인증 세션 분리(소프트 로그아웃). 로그아웃해도 apnsToken/fcmToken 은
+  // 보존하고, 이 상태값 하나로 "어떤 푸시를 보낼지"만 게이팅한다 → 의도치 않은 로그아웃에도 재참여 푸시 유지.
+  //  - active     : 정상 로그인 상태. 콘텐츠(가족 내용) 푸시 발송.
+  //  - expired    : 의도치 않은 세션 만료(refresh 실패). 콘텐츠 차단, 재로그인 유도 재참여 푸시만.
+  //  - logged_out : 명시적 로그아웃. 콘텐츠 차단, 재참여 푸시만.
+  // 로그인/토큰 재등록 시 active 로 복귀. 콘텐츠=active만, 재참여=active 아님(토큰 살아있을 때).
+  sessionState           SessionState       @default(active) @map("session_state")
+  answers                Answer[]
+  memberships            FamilyMembership[]
+  moodRecords            MoodRecord[]
+  notifications          Notification[]
+  accessLogs             UserAccessLog[]
+  refreshTokens          UserRefreshToken[]
+  family                 Family?            @relation(fields: [familyId], references: [id])
 
   @@map("users")
 }
@@ -90,23 +97,23 @@ model Family {
 }
 
 model FamilyMembership {
-  id                String    @id @default(uuid())
-  userId            String    @map("user_id")
-  familyId          String    @map("family_id")
-  role              UserRole  @default(OTHER)
-  joinedAt          DateTime  @default(now()) @map("joined_at")
-  hearts            Int       @default(5)
-  nickname          String?
-  colorId           String?   @default("loved") @map("color_id")
-  nicknameChangedAt DateTime? @map("nickname_changed_at")
-  skippedDate       DateTime? @map("skipped_date") @db.Date
+  id                 String    @id @default(uuid())
+  userId             String    @map("user_id")
+  familyId           String    @map("family_id")
+  role               UserRole  @default(OTHER)
+  joinedAt           DateTime  @default(now()) @map("joined_at")
+  hearts             Int       @default(5)
+  nickname           String?
+  colorId            String?   @default("loved") @map("color_id")
+  nicknameChangedAt  DateTime? @map("nickname_changed_at")
+  skippedDate        DateTime? @map("skipped_date") @db.Date
   // 그룹별 데일리 +1 지급 추적. User.lastHeartGrantedAt 의 글로벌 한계를
   // 보완 — 같은 KST 날짜에 그룹 A→B 전환 시 두 그룹 모두 +1 받게 한다.
   // atomic test-and-set: WHERE { lastHeartGrantedAt: null OR < kstToday } 으로
   // 동시 호출에서도 정확히 1번만 갱신.
   lastHeartGrantedAt DateTime? @map("last_heart_granted_at")
-  family            Family    @relation(fields: [familyId], references: [id])
-  user              User      @relation(fields: [userId], references: [id])
+  family             Family    @relation(fields: [familyId], references: [id])
+  user               User      @relation(fields: [userId], references: [id])
 
   @@unique([userId, familyId])
   @@map("family_memberships")
@@ -212,14 +219,14 @@ model MoodRecord {
 /// 사용자가 email+password 로 가입을 시도하면 6자리 코드를 해시하여 저장한다.
 /// 회원가입 완료(consumed=true) 후에는 cleanup 대상.
 model EmailVerification {
-  id         String   @id @default(uuid())
-  email      String
-  purpose    String   @default("SIGNUP") // 'SIGNUP' | 'LOGIN' 등 확장 여지
-  codeHash   String   @map("code_hash")
-  expiresAt  DateTime @map("expires_at")
-  attempts   Int      @default(0)
-  consumed   Boolean  @default(false)
-  createdAt  DateTime @default(now()) @map("created_at")
+  id        String   @id @default(uuid())
+  email     String
+  purpose   String   @default("SIGNUP") // 'SIGNUP' | 'LOGIN' 등 확장 여지
+  codeHash  String   @map("code_hash")
+  expiresAt DateTime @map("expires_at")
+  attempts  Int      @default(0)
+  consumed  Boolean  @default(false)
+  createdAt DateTime @default(now()) @map("created_at")
 
   @@index([email, purpose])
   @@map("email_verifications")
@@ -255,4 +262,11 @@ enum NotificationType {
 enum ApnsEnvironment {
   sandbox
   production
+}
+
+// (MG-141) 인증 세션 상태. 디바이스 토큰 보존과 무관하게 푸시 게이팅에만 사용.
+enum SessionState {
+  active
+  expired
+  logged_out
 }

--- a/src/__tests__/reminderScheduler.test.ts
+++ b/src/__tests__/reminderScheduler.test.ts
@@ -43,6 +43,7 @@ const mockUser = {
   fcmToken: null,
   locale: 'ko',
   notifQuestion: true,
+  sessionState: 'active', // (MG-141) 활성 세션이라야 콘텐츠 푸시 발송
 };
 
 describe('getKstMidnightUtc', () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -305,7 +305,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
       const userId = req.params.userId;
       const user = await prisma.user.findUnique({
         where: { id: userId },
-        select: { id: true, apnsToken: true, fcmToken: true, locale: true, notifQuestion: true, familyId: true },
+        select: { id: true, apnsToken: true, fcmToken: true, locale: true, notifQuestion: true, familyId: true, sessionState: true },
       });
       if (!user) { res.status(404).json({ error: 'user not found' }); return; }
 
@@ -342,6 +342,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
           locale: user.locale,
           notifQuestion: user.notifQuestion,
           familyId: user.familyId,
+          sessionState: user.sessionState, // (MG-141) active/expired/logged_out — 콘텐츠 vs 재참여 푸시 게이트
         },
         memberships: memberships.map((m) => ({
           familyId: m.familyId,

--- a/src/reminderScheduler.ts
+++ b/src/reminderScheduler.ts
@@ -4,6 +4,7 @@ import { NotificationService } from './services/NotificationService';
 import { PushNotificationService } from './services/PushNotificationService';
 import { getPushMessages } from './utils/i18n/push';
 import { isInQuietHours } from './utils/quietHours';
+import { canSendContentPush } from './utils/pushPolicy';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
@@ -85,6 +86,7 @@ export async function sendDailyReminders(): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
+          sessionState: true,
           quietHoursEnabled: true,
           quietHoursStart: true,
           quietHoursEnd: true,
@@ -227,6 +229,7 @@ export async function sendDailyReminders(): Promise<void> {
   const pushTasks: Promise<unknown>[] = [];
   for (const [userId, user] of userInfoMap) {
     if (!user.notifQuestion) continue;
+    if (!canSendContentPush(user)) continue; // (MG-141) 로그아웃/만료 세션엔 콘텐츠 푸시 금지
     if (isInQuietHours(user)) continue;
     const unanswered = userHasUnanswered.get(userId) ?? false;
     const { title, body } = makeBody(user.locale, unanswered);

--- a/src/services/AnswerService.ts
+++ b/src/services/AnswerService.ts
@@ -12,6 +12,7 @@ import { PushNotificationService } from './PushNotificationService';
 import { tryFinalizeDailyQuestion } from './dailyQuestionCompletion';
 import { getPushMessages } from '../utils/i18n/push';
 import { isInQuietHours } from '../utils/quietHours';
+import { canSendContentPush } from '../utils/pushPolicy';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
@@ -140,7 +141,7 @@ export class AnswerService {
           user: {
             select: {
               id: true, apnsToken: true, apnsEnvironment: true, fcmToken: true,
-              locale: true, notifAnswer: true,
+              locale: true, notifAnswer: true, sessionState: true,
               quietHoursEnabled: true, quietHoursStart: true, quietHoursEnd: true,
             },
           },
@@ -173,6 +174,8 @@ export class AnswerService {
       const pushTasks: Promise<unknown>[] = [];
       for (const member of otherMembers) {
         if (!member.notifAnswer) continue;
+        // (MG-141) 로그아웃/만료 세션엔 콘텐츠(가족 답변) 푸시 금지 — 토큰은 보존되지만 발송 게이트로 차단.
+        if (!canSendContentPush(member)) continue;
         // quiet hours 면 푸시만 건너뜀. DB 알림은 1단계에서 이미 저장됨.
         if (isInQuietHours(member)) continue;
         const msgs = getPushMessages(member.locale);

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -29,6 +29,12 @@ export async function issueTokensForUser(
   await prisma.userRefreshToken.create({
     data: { userId: internalUserId, tokenHash, expiresAt },
   });
+  // (MG-141) 로그인 = 세션 활성화. 이전 로그아웃/만료(soft logout)로 비활성이던 상태를 active 로
+  // 복귀시켜 콘텐츠 푸시를 재개하고 재참여 푸시는 멈춘다. 모든 로그인 경로(social/email)의 단일 지점.
+  await prisma.user.update({
+    where: { id: internalUserId },
+    data: { sessionState: 'active' },
+  });
   return { token, refresh_token };
 }
 
@@ -343,9 +349,13 @@ export class AuthService {
   }
 
   /**
-   * 로그아웃 — 디바이스 푸시 토큰(APNs/FCM) 제거 + active refresh 토큰 전체 revoke
-   * 동일 디바이스로 다른 계정 로그인 시 이전 계정에 푸시가 가는 문제 방지.
-   * refresh 토큰을 함께 무효화해야 logout 이후 동일 토큰으로 access 재발급 불가.
+   * 로그아웃 — (MG-141) 디바이스 푸시 토큰(APNs/FCM)은 "보존"하고 sessionState='logged_out' 으로 전환.
+   * active refresh 토큰은 전체 revoke 해 동일 토큰으로 access 재발급은 막는다.
+   *
+   * 토큰을 NULL 로 지우던 이전 동작은 의도치 않은 로그아웃 시 가족 재촉 푸시까지 끊어 연결을 단절시켰다.
+   * 이제 토큰을 남겨 "다시 로그인" 재참여 푸시를 보낼 수 있게 하고, 콘텐츠 푸시는 sessionState 게이트로 차단한다.
+   * 동일 기기를 다른 계정이 인계받으면 registerDeviceToken 의 토큰 회수 불변식이 이 토큰을 NULL 로 만들어
+   * 프라이버시(이전 계정 대상 푸시가 새 계정 기기로 가는 것)를 보호한다.
    */
   async logout(userId: string): Promise<void> {
     const user = await prisma.user.findUnique({ where: { userId }, select: { id: true } });
@@ -356,13 +366,25 @@ export class AuthService {
     await prisma.$transaction([
       prisma.user.update({
         where: { id: user.id },
-        data: { apnsToken: null, fcmToken: null },
+        data: { sessionState: 'logged_out' },
       }),
       prisma.userRefreshToken.updateMany({
         where: { userId: user.id, revokedAt: null },
         data: { revokedAt: new Date() },
       }),
     ]);
+  }
+
+  /**
+   * (MG-141) 의도치 않은 세션 만료 표시 — refresh 실패(만료/재사용/미등록) 시 호출.
+   * 이미 logged_out 인 유저는 그대로 두고, active 인 유저만 expired 로 내려 재참여 푸시 대상이 되게 한다.
+   * 디바이스 토큰은 건드리지 않는다(보존).
+   */
+  private async markSessionExpired(internalUserId: string): Promise<void> {
+    await prisma.user.updateMany({
+      where: { id: internalUserId, sessionState: 'active' },
+      data: { sessionState: 'expired' },
+    });
   }
 
   async refreshToken(refreshToken: string): Promise<TokenRefreshResult> {
@@ -383,6 +405,7 @@ export class AuthService {
     // 마이그레이션 직후 호환을 위해 grace period 가 필요하면 여기서 신규 발급 흐름으로
     // 폴백할 수 있으나, 보안 우선으로 거부 + 클라이언트 재로그인 유도 (MG-33 흐름).
     if (!record) {
+      await this.markSessionExpired(user.id); // (MG-141) 의도치 않은 만료 → 재참여 푸시 대상
       throw Errors.unauthorized('유효하지 않은 리프레시 토큰입니다.');
     }
 
@@ -393,10 +416,12 @@ export class AuthService {
         where: { userId: user.id, revokedAt: null },
         data: { revokedAt: new Date() },
       });
+      await this.markSessionExpired(user.id); // (MG-141)
       throw Errors.unauthorized('재사용이 감지된 리프레시 토큰입니다. 다시 로그인해주세요.');
     }
 
     if (record.expiresAt.getTime() < Date.now()) {
+      await this.markSessionExpired(user.id); // (MG-141)
       throw Errors.unauthorized('만료된 리프레시 토큰입니다.');
     }
 

--- a/src/services/NudgeService.ts
+++ b/src/services/NudgeService.ts
@@ -4,6 +4,7 @@ import { NotificationService } from './NotificationService';
 import { PushNotificationService } from './PushNotificationService';
 import { getPushMessages } from '../utils/i18n/push';
 import { isInQuietHours } from '../utils/quietHours';
+import { canSendContentPush, shouldSendReengagePush } from '../utils/pushPolicy';
 
 const notificationService = new NotificationService();
 const pushService = new PushNotificationService();
@@ -116,16 +117,53 @@ export class NudgeService {
     );
 
     // 푸시 발송 — Lambda 환경에서는 반드시 await 해야 함.
-    // 알림 선호도 체크: notifNudge 꺼졌거나 quiet hours 면 푸시 발송 건너뜀 (DB 알림 기록은 유지)
+    // (MG-141) 세션 상태로 발송 종류를 가른다:
+    //   - active            : 기존 콘텐츠 푸시(가족 이름 포함). notifNudge 토글 + quietHours 존중.
+    //   - expired/logged_out: 가족 내용 없는 재참여("다시 로그인") 푸시. 토큰을 보존하므로 발송 가능.
+    // DB 알림 기록은 두 경우 모두 유지(위에서 생성). 빈도는 상단 24h 3회 rate-limit 으로 자연 제한.
     const pushTasks: Promise<void>[] = [];
-    if (target.notifNudge && !isInQuietHours(target)) {
+    if (canSendContentPush(target)) {
+      if (target.notifNudge && !isInQuietHours(target)) {
+        if (target.apnsToken) {
+          pushTasks.push(
+            (async () => {
+              const badgeCount = await notificationService.getUnreadCount(target.id);
+              await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment, nudgeNotificationId);
+            })().catch((e) => {
+              console.warn('[Nudge] APNs 푸시 실패:', e);
+            })
+          );
+        }
+        if (target.fcmToken) {
+          pushTasks.push(
+            (async () => {
+              const unreadCount = await notificationService.getUnreadCount(target.id);
+              await pushService.sendFcmPush(
+                target.fcmToken!,
+                nudgeTitle,
+                nudgeBody,
+                'ANSWER_REQUEST',
+                undefined,
+                nudgeNotificationId,
+                unreadCount
+              );
+            })().catch((e) => {
+              console.warn('[Nudge] FCM 푸시 실패:', e);
+            })
+          );
+        }
+      }
+    } else if (shouldSendReengagePush(target) && !isInQuietHours(target)) {
+      // 가족 내용(이름/질문) 미포함 재참여 문구. notifNudge 토글은 "활성 세션 콘텐츠 알림" 설정이라
+      // 비활성 상태의 재참여엔 적용하지 않되 quietHours 는 존중.
+      const reMsgs = getPushMessages(target.locale);
       if (target.apnsToken) {
         pushTasks.push(
           (async () => {
             const badgeCount = await notificationService.getUnreadCount(target.id);
-            await pushService.sendApnsPush(target.apnsToken!, nudgeTitle, nudgeBody, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment, nudgeNotificationId);
+            await pushService.sendApnsPush(target.apnsToken!, reMsgs.reengage.title, reMsgs.reengage.body, 'ANSWER_REQUEST', badgeCount, target.apnsEnvironment, nudgeNotificationId);
           })().catch((e) => {
-            console.warn('[Nudge] APNs 푸시 실패:', e);
+            console.warn('[Nudge] 재참여 APNs 푸시 실패:', e);
           })
         );
       }
@@ -133,17 +171,9 @@ export class NudgeService {
         pushTasks.push(
           (async () => {
             const unreadCount = await notificationService.getUnreadCount(target.id);
-            await pushService.sendFcmPush(
-              target.fcmToken!,
-              nudgeTitle,
-              nudgeBody,
-              'ANSWER_REQUEST',
-              undefined,
-              nudgeNotificationId,
-              unreadCount
-            );
+            await pushService.sendFcmPush(target.fcmToken!, reMsgs.reengage.title, reMsgs.reengage.body, 'ANSWER_REQUEST', undefined, nudgeNotificationId, unreadCount);
           })().catch((e) => {
-            console.warn('[Nudge] FCM 푸시 실패:', e);
+            console.warn('[Nudge] 재참여 FCM 푸시 실패:', e);
           })
         );
       }

--- a/src/services/QuestionService.ts
+++ b/src/services/QuestionService.ts
@@ -14,6 +14,7 @@ import { NotificationService } from './NotificationService';
 import { PushNotificationService } from './PushNotificationService';
 import { getPushMessages } from '../utils/i18n/push';
 import { isInQuietHours } from '../utils/quietHours';
+import { canSendContentPush } from '../utils/pushPolicy';
 
 export class QuestionService {
   /**
@@ -672,6 +673,7 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
           fcmToken: true,
           locale: true,
           notifQuestion: true,
+          sessionState: true,
           quietHoursEnabled: true,
           quietHoursStart: true,
           quietHoursEnd: true,
@@ -704,6 +706,7 @@ async function notifyNewQuestion(familyId: string): Promise<void> {
   const pushTasks: Promise<unknown>[] = [];
   for (const m of members) {
     if (!m.notifQuestion) continue;
+    if (!canSendContentPush(m)) continue; // (MG-141) 로그아웃/만료 세션엔 콘텐츠 푸시 금지
     if (isInQuietHours(m)) continue;
     const msgs = getPushMessages(m.locale);
     const title = msgs.newQuestion.title;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -263,9 +263,10 @@ export class UserService {
     });
 
     // environment 미지정 시(구형 클라이언트) production 가정 — v1 배포 유저의 하위호환 경로.
+    // (MG-141) 토큰 등록 = 활성 세션 신호 → sessionState active 복귀(재참여 푸시 중단, 콘텐츠 재개).
     await prisma.user.update({
       where: { id: user.id },
-      data: { apnsToken: token, apnsEnvironment: environment ?? 'production' },
+      data: { apnsToken: token, apnsEnvironment: environment ?? 'production', sessionState: 'active' },
     });
   }
 
@@ -284,7 +285,8 @@ export class UserService {
       data: { fcmToken: null },
     });
 
-    await prisma.user.update({ where: { id: user.id }, data: { fcmToken: token } });
+    // (MG-141) 토큰 등록 = 활성 세션 신호 → sessionState active 복귀.
+    await prisma.user.update({ where: { id: user.id }, data: { fcmToken: token, sessionState: 'active' } });
   }
 
   /**

--- a/src/services/__tests__/QuestionService.test.ts
+++ b/src/services/__tests__/QuestionService.test.ts
@@ -316,8 +316,8 @@ describe('notifyNewQuestion (MG-29 회귀)', () => {
     // 가족 family-A 의 멤버 2명. 한 명(u2)은 활성 가족이 다른 그룹(B) 이지만
     // family-A 의 FamilyMembership 행은 존재하므로 알림 대상에 포함되어야 한다.
     mockPrismaFamilyMembershipFindMany.mockResolvedValueOnce([
-      { user: { id: 'u1', apnsToken: 'tok-a', apnsEnvironment: 'sandbox', fcmToken: null, locale: 'ko', notifQuestion: true } },
-      { user: { id: 'u2', apnsToken: 'tok-b', apnsEnvironment: 'production', fcmToken: null, locale: 'ko', notifQuestion: true } },
+      { user: { id: 'u1', apnsToken: 'tok-a', apnsEnvironment: 'sandbox', fcmToken: null, locale: 'ko', notifQuestion: true, sessionState: 'active' } },
+      { user: { id: 'u2', apnsToken: 'tok-b', apnsEnvironment: 'production', fcmToken: null, locale: 'ko', notifQuestion: true, sessionState: 'active' } },
     ]);
 
     const { notifyNewQuestion } = await import('../QuestionService');

--- a/src/utils/__tests__/pushPolicy.test.ts
+++ b/src/utils/__tests__/pushPolicy.test.ts
@@ -1,0 +1,31 @@
+import { canSendContentPush, shouldSendReengagePush } from '../pushPolicy';
+
+// (MG-141) 소프트 로그아웃 게이팅 정책 — 디바이스 토큰은 보존하되 sessionState 로 발송 종류를 가른다.
+describe('pushPolicy (MG-141)', () => {
+  describe('canSendContentPush — 콘텐츠(가족 내용) 푸시', () => {
+    it('active 세션에만 콘텐츠 푸시를 허용한다', () => {
+      expect(canSendContentPush({ sessionState: 'active' })).toBe(true);
+    });
+    it('expired / logged_out 세션에는 콘텐츠 푸시를 차단한다 (프라이버시 회귀 방지)', () => {
+      expect(canSendContentPush({ sessionState: 'expired' })).toBe(false);
+      expect(canSendContentPush({ sessionState: 'logged_out' })).toBe(false);
+    });
+  });
+
+  describe('shouldSendReengagePush — 재참여(재로그인 유도) 푸시', () => {
+    it('비활성 세션(expired/logged_out)을 재참여 대상으로 본다', () => {
+      expect(shouldSendReengagePush({ sessionState: 'expired' })).toBe(true);
+      expect(shouldSendReengagePush({ sessionState: 'logged_out' })).toBe(true);
+    });
+    it('active 세션은 재참여 대상이 아니다', () => {
+      expect(shouldSendReengagePush({ sessionState: 'active' })).toBe(false);
+    });
+  });
+
+  it('콘텐츠와 재참여는 상호 배타적이다 (한 세션에 둘 다 보내지 않는다)', () => {
+    for (const sessionState of ['active', 'expired', 'logged_out']) {
+      const t = { sessionState };
+      expect(canSendContentPush(t) && shouldSendReengagePush(t)).toBe(false);
+    }
+  });
+});

--- a/src/utils/i18n/push.ts
+++ b/src/utils/i18n/push.ts
@@ -27,6 +27,9 @@ interface PushMessages {
     answered: { title: string; body: string };
     unanswered: { title: string; body: string };
   };
+  // MG-141: 로그아웃/세션만료(비활성) 유저용 재참여 문구. 가족 이름·질문 내용을 절대 포함하지 않는다
+  // (로그아웃 상태로 토큰만 살아있는 기기에 가족 콘텐츠가 새는 것을 막기 위한 제약).
+  reengage: { title: string; body: string };
 }
 
 const messagesByLocale: Record<Locale, PushMessages> = {
@@ -63,6 +66,10 @@ const messagesByLocale: Record<Locale, PushMessages> = {
         body: '그룹에 접속해서 답변을 달아봐요',
       },
     },
+    reengage: {
+      title: '몽글',
+      body: '가족이 회원님을 기다리고 있어요. 다시 로그인해 확인해 주세요.',
+    },
   },
   en: {
     newQuestion: {
@@ -97,6 +104,10 @@ const messagesByLocale: Record<Locale, PushMessages> = {
         body: 'Open the group and leave your answer',
       },
     },
+    reengage: {
+      title: 'Mongle',
+      body: 'Your family is waiting for you. Please sign in again to catch up.',
+    },
   },
   ja: {
     newQuestion: {
@@ -130,6 +141,10 @@ const messagesByLocale: Record<Locale, PushMessages> = {
         title: '今日の質問にまだ回答していません',
         body: 'グループに入って回答してみましょう',
       },
+    },
+    reengage: {
+      title: 'Mongle',
+      body: 'ご家族が待っています。もう一度ログインして確認してください。',
     },
   },
 };

--- a/src/utils/pushPolicy.ts
+++ b/src/utils/pushPolicy.ts
@@ -1,0 +1,24 @@
+/**
+ * (MG-141) 푸시 게이팅 정책 — "디바이스 토큰을 인증 세션에서 분리"한 소프트 로그아웃의 핵심.
+ *
+ * 로그아웃/세션만료에도 apnsToken/fcmToken 은 보존하므로, 무엇을 보낼지는 User.sessionState 로 가른다:
+ *   - 콘텐츠(가족 내용) 푸시 : active 일 때만. 로그아웃/만료된 기기에 가족 답변·질문이 새는 것을 차단.
+ *   - 재참여(재로그인 유도) 푸시 : active 가 아닐 때(=expired|logged_out) + 토큰 생존 시.
+ *                                "다시 로그인" 유도용으로 가족 내용은 절대 포함하지 않는다.
+ *
+ * 같은 기기를 다른 유저가 인계받으면 registerDeviceToken 의 토큰 회수 불변식으로 이전 유저 토큰이
+ * NULL 이 되므로, 비활성 유저 대상 재참여 푸시가 새 유저 기기로 가는 일은 없다.
+ */
+export interface PushGateTarget {
+  sessionState: string;
+}
+
+/** 콘텐츠(가족 내용) 푸시 허용 여부. notif* 토글·quietHours 는 호출부에서 별도 확인. */
+export function canSendContentPush(target: PushGateTarget): boolean {
+  return target.sessionState === 'active';
+}
+
+/** 재참여 푸시 대상 여부. 세션이 비활성(만료/로그아웃)인 경우. 토큰 생존 여부는 호출부에서 확인. */
+export function shouldSendReengagePush(target: PushGateTarget): boolean {
+  return target.sessionState !== 'active';
+}


### PR DESCRIPTION
## 배경 / 문제
의도치 않은 로그아웃(refresh 실패·401)이나 명시적 로그아웃 시 서버가 `apnsToken`/`fcmToken` 을 **NULL** 로 지워, "글 작성 재촉하기" 등 중요 푸시가 끊기고 가족 간 연결이 단절됐다. 근본 원인은 **디바이스 푸시 토큰 수명이 인증 세션 수명과 묶여 있던 것**.

## 해결 (소프트 로그아웃 / 토큰-세션 분리)
디바이스 토큰을 **보존**하고, `User.sessionState` 한 필드로 *무엇을 보낼지*만 게이팅한다.

| 상태 | 의미 | 콘텐츠 푸시 | 재참여 푸시 |
|------|------|:---:|:---:|
| `active` | 정상 로그인 | ✅ | ❌ |
| `expired` | 의도치 않은 만료(refresh 실패) | ❌ | ✅ |
| `logged_out` | 명시적 로그아웃 | ❌ | ✅ |

## 변경 사항
- **schema**: `User.sessionState` + `SessionState` enum 추가 (default `active`, 비파괴적)
- **AuthService**: 로그인=`active` 복귀(`issueTokensForUser` 단일 지점) · `logout`=토큰 보존 + `logged_out` (refresh revoke 유지) · refresh 실패 3경로=`expired`(`markSessionExpired`, `active`일 때만 강등)
- **UserService**: 토큰 재등록 시 `active` 복귀. **동일 토큰 회수 불변식 유지** → 계정 전환 시 프라이버시 보호
- **pushPolicy.ts**: `canSendContentPush`(active만) / `shouldSendReengagePush`(비활성) 단일 정책
- **콘텐츠 게이트**: Nudge/Answer/Question/reminder 4개 발송부에 적용 → 토큰 보존으로 생길 *가족 내용 누출 회귀* 차단
- **재참여 푸시**: Nudge 경로에서 비활성 유저에게 **가족 내용 없는** "다시 로그인" 문구 발송(i18n ko/en/ja). 빈도는 기존 24h 3회 nudge rate-limit 으로 자연 제한
- **진단**: `admin/user-push-state` 에 `sessionState` 노출
- **test**: `pushPolicy` 단위 테스트(5) 추가 + 기존 푸시 픽스처에 `sessionState` 보강

## 프라이버시 (핵심 Edge Case)
A 로그아웃 → 동일 기기 B 로그인 시: B의 토큰 등록이 `registerDeviceToken` 의 **토큰 회수 불변식**으로 A의 토큰을 NULL 처리 → A 대상 재참여 푸시가 B 기기로 가지 않음. ✅

## ⚠️ 배포 시 주의
- 이 변경은 `session_state` **컬럼 추가**를 포함한다. 프로젝트는 migration 폴더 없이 `prisma db push` 방식이므로 **prod 배포 시 `prisma db push`(또는 동등 DDL)로 컬럼을 먼저 추가**해야 한다. default `active` 라 기존 레코드는 자동으로 정상 동작.
- 신규 엔드포인트는 없어 tsoa `routes.ts` 변경은 없음(404 트랩 무관). 그래도 배포는 `npm run build` 포함.

## 테스트
- `pushPolicy` 5/5 통과, 영향받은 reminder/Question 스위트 통과.
- 기존 실패 4건(FamilyService 3 + AuthService refresh 1)은 **이 PR과 무관한 prisma mock 미비**로 main 에서도 동일하게 실패(본 PR이 새로 깨뜨린 테스트 0건).

## 후속 (별도 이슈)
iOS(TCA)·Android(MVI) 클라이언트 정책 통일(세션만료 보존 명문화, 등록 401 비승격, Android 서버 logout 호출 통일). 설계: `Mongle/Work.md`.

Jira: MG-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)