### PR TITLE
fix(shop): 장식 카탈로그 가격 50으로 통일

### DIFF
--- a/src/constants/shopCatalog.ts
+++ b/src/constants/shopCatalog.ts
@@ -35,15 +35,15 @@ export const SHOP_CATALOG: ShopCatalogItem[] = [
   { id: 'bg_cherry_blossom', kind: 'background', name: '벚꽃길', price: 50, sortOrder: 6 },
 
   // 장식 (kind=decoration) — 개인(유저) 소유. slot 당 1개 장착.
-  { id: 'deco_flower_crown', kind: 'decoration', name: '들꽃 화관', price: 35, slot: 'head', sortOrder: 1 },
-  { id: 'deco_star_halo', kind: 'decoration', name: '별 후광', price: 40, slot: 'head', sortOrder: 2 },
-  { id: 'deco_satin_ribbon', kind: 'decoration', name: '새틴 리본', price: 25, slot: 'head', sortOrder: 3 },
+  { id: 'deco_flower_crown', kind: 'decoration', name: '들꽃 화관', price: 50, slot: 'head', sortOrder: 1 },
+  { id: 'deco_star_halo', kind: 'decoration', name: '별 후광', price: 50, slot: 'head', sortOrder: 2 },
+  { id: 'deco_satin_ribbon', kind: 'decoration', name: '새틴 리본', price: 50, slot: 'head', sortOrder: 3 },
   { id: 'deco_balloon_bunch', kind: 'decoration', name: '풍선 다발', price: 50, slot: 'head', sortOrder: 4 },
-  { id: 'deco_santa_hat', kind: 'decoration', name: '산타 모자', price: 60, slot: 'head', isSeasonal: true, sortOrder: 5 },
-  { id: 'deco_angel_wings', kind: 'decoration', name: '천사 날개', price: 45, slot: 'back', sortOrder: 1 },
-  { id: 'deco_cape', kind: 'decoration', name: '망토', price: 40, slot: 'back', sortOrder: 2 },
-  { id: 'deco_sneakers', kind: 'decoration', name: '운동화', price: 30, slot: 'feet', sortOrder: 1 },
-  { id: 'deco_cloud_pad', kind: 'decoration', name: '구름 받침', price: 35, slot: 'feet', sortOrder: 2 },
+  { id: 'deco_santa_hat', kind: 'decoration', name: '산타 모자', price: 50, slot: 'head', isSeasonal: true, sortOrder: 5 },
+  { id: 'deco_angel_wings', kind: 'decoration', name: '천사 날개', price: 50, slot: 'back', sortOrder: 1 },
+  { id: 'deco_cape', kind: 'decoration', name: '망토', price: 50, slot: 'back', sortOrder: 2 },
+  { id: 'deco_sneakers', kind: 'decoration', name: '운동화', price: 50, slot: 'feet', sortOrder: 1 },
+  { id: 'deco_cloud_pad', kind: 'decoration', name: '구름 받침', price: 50, slot: 'feet', sortOrder: 2 },
 ];
 
 export const CATALOG_BY_ID: Record<string, ShopCatalogItem> = SHOP_CATALOG.reduce(

--- a/src/services/__tests__/ShopService.test.ts
+++ b/src/services/__tests__/ShopService.test.ts
@@ -93,8 +93,8 @@ describe('ShopService.getCatalog', () => {
     expect(byId['bg_cozy_home']).toMatchObject({ name: '따뜻한 집', price: 0 });
     expect(byId['bg_spring_field']).toMatchObject({ name: '봄 들판', price: 50 });
     expect(byId['bg_snow_village']).toMatchObject({ name: '눈오는 마을', price: 50, isSeasonal: true });
-    expect(byId['deco_satin_ribbon']).toMatchObject({ name: '새틴 리본', price: 25, slot: 'head' });
-    expect(byId['deco_santa_hat']).toMatchObject({ price: 60, slot: 'head', isSeasonal: true });
+    expect(byId['deco_satin_ribbon']).toMatchObject({ name: '새틴 리본', price: 50, slot: 'head' });
+    expect(byId['deco_santa_hat']).toMatchObject({ price: 50, slot: 'head', isSeasonal: true });
     // 계약에 없는 bg_forest 가 제거됐는지 확인
     expect(byId['bg_forest']).toBeUndefined();
   });
@@ -175,14 +175,14 @@ describe('ShopService.purchase', () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaUserDecorationFindUnique.mockResolvedValue(null); // 미보유
     mockPrismaFamilyMembershipUpdateMany.mockResolvedValue({ count: 1 });
-    mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ hearts: 35 });
+    mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ hearts: 50 });
 
-    const result = await service.purchase('kakao:123', 'deco_flower_crown'); // price 35
+    const result = await service.purchase('kakao:123', 'deco_flower_crown'); // price 50
     expect(mockPrismaFamilyMembershipUpdateMany).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { hearts: { decrement: 35 } } })
+      expect.objectContaining({ data: { hearts: { decrement: 50 } } })
     );
     expect(mockPrismaUserDecorationCreate).toHaveBeenCalled();
-    expect(result.heartsRemaining).toBe(35);
+    expect(result.heartsRemaining).toBe(50);
   });
 
   it('이미 소유한 아이템은 멱등 — 재차감/create 없이 현재 하트 반환', async () => {
@@ -220,7 +220,7 @@ describe('ShopService.purchase', () => {
     mockPrismaFamilyMembershipUpdateMany.mockResolvedValue({ count: 1 });
     mockPrismaFamilyMembershipFindUnique.mockResolvedValue({ hearts: 0 });
 
-    await service.purchase('kakao:123', 'bg_beach'); // price 35
+    await service.purchase('kakao:123', 'bg_beach'); // price 50
     expect(mockPrismaUserBackgroundCreate).toHaveBeenCalledWith(
       expect.objectContaining({ data: { userId: 'db-user-id', itemId: 'bg_beach' } })
     );


### PR DESCRIPTION
## 변경
`shopCatalog.ts` 장식(decoration) 9종 가격을 모두 **50**으로 통일 — 들꽃 화관/별 후광/새틴 리본/풍선 다발/산타 모자/천사 날개/망토/운동화/구름 받침. (배경과 동일가)

실제 앱 노출 가격은 이 서버 카탈로그 기준. iOS fallback 카탈로그 변경은 별도 PR(rrheon/Mongle#136).

## 검증
- `ShopService.test.ts` 가격 단언 50으로 갱신
- `tsc --noEmit` 0에러, ShopService 테스트 23/23

## 배포
머지 후 `npm run build` → deploy. (db push 불필요 — 카탈로그는 상수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)