### PR TITLE
feat(shop): 장식 착용 모델 단일화 (전체 1개 착용)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,10 +44,8 @@ model User {
   quietHoursEnd          String             @default("08:00") @map("quiet_hours_end")
   // 이메일/비밀번호 로그인용 bcrypt 해시. 소셜 전용 계정이면 NULL.
   passwordHash           String?            @map("password_hash")
-  // 상점 — 장착 중인 꾸미기 아이템 슬롯. null 이면 미장착. 아이템 id 는 SHOP_CATALOG 참조.
-  equippedHeadId         String?            @map("equipped_head_id")
-  equippedBackId         String?            @map("equipped_back_id")
-  equippedFeetId         String?            @map("equipped_feet_id")
+  // 상점 — 현재 착용 중인 꾸미기 1개(전역 단일). null = 미착용. id 는 SHOP_CATALOG 참조.
+  equippedDecorationId   String?            @map("equipped_decoration_id")
   // (MG-141) 푸시 토큰 ↔ 인증 세션 분리(소프트 로그아웃). 로그아웃해도 apnsToken/fcmToken 은
   // 보존하고, 이 상태값 하나로 "어떤 푸시를 보낼지"만 게이팅한다 → 의도치 않은 로그아웃에도 재참여 푸시 유지.
   //  - active     : 정상 로그인 상태. 콘텐츠(가족 내용) 푸시 발송.

--- a/scripts/backfill-equipped-single.sql
+++ b/scripts/backfill-equipped-single.sql
@@ -1,0 +1,23 @@
+-- 장식 "착용 모델 단일화" 백필 SQL (feat/deco-single-equip)
+--
+-- 목적: 기존 User 의 3컬럼(equipped_head_id / equipped_back_id / equipped_feet_id)
+--       장착 데이터를 단일 컬럼 equipped_decoration_id 로 이전한다.
+--
+-- 우선순위: head > back > feet (COALESCE 순서). 다중 장착 유저는 head 우선 1개만
+--          살아남고 나머지는 폐기된다. 풍선(deco_balloon_bunch)은 이번 범위에선
+--          여전히 head slot 이므로 그대로 단일 id 로 보존된다.
+--
+-- 실행 시점: prisma db push #1(equipped_decoration_id 컬럼 추가, 구 3컬럼은 아직 보존)
+--           직후 1회. 행수 검증 후 db push #2(구 3컬럼 drop) 진행.
+--
+-- ⚠️ prod 실행은 사용자 몫. 실행 전 dev 스테이지 리허설 권장.
+
+UPDATE "User"
+SET equipped_decoration_id = COALESCE(equipped_head_id, equipped_back_id, equipped_feet_id)
+WHERE equipped_decoration_id IS NULL
+  AND (equipped_head_id IS NOT NULL
+    OR equipped_back_id IS NOT NULL
+    OR equipped_feet_id IS NOT NULL);
+
+-- 백필 검증: 이전 대상 건수 vs 단일 컬럼 채워진 건수 확인
+-- SELECT count(*) AS backfilled FROM "User" WHERE equipped_decoration_id IS NOT NULL;

--- a/src/controllers/ShopController.ts
+++ b/src/controllers/ShopController.ts
@@ -16,7 +16,6 @@ import {
   ShopInventoryResponse,
   EquipResponse,
   PurchaseResponse,
-  DecorationSlot,
 } from '../models';
 
 interface PurchaseRequest {
@@ -24,8 +23,7 @@ interface PurchaseRequest {
 }
 
 interface EquipRequest {
-  slot: DecorationSlot;
-  /** 미전달 시 해당 슬롯 장착 해제 */
+  /** 미전달 시 장착 해제(전역 단일) */
   itemId?: string;
 }
 
@@ -85,7 +83,7 @@ export class ShopController extends Controller {
     @Request() req: AuthRequest,
     @Body() body: EquipRequest
   ): Promise<EquipResponse> {
-    return this.shopService.equipDecoration(req.user.userId, body.slot, body.itemId);
+    return this.shopService.equipDecoration(req.user.userId, body.itemId);
   }
 
   /**

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -211,21 +211,16 @@ export interface ShopCatalogItemDto {
   sortOrder?: number;
 }
 
-export interface EquippedDecorationsDto {
-  head?: string;
-  back?: string;
-  feet?: string;
-}
-
 export interface ShopInventoryResponse {
   ownedDecorationIds: string[];
-  equippedDecorations: EquippedDecorationsDto;
+  // 현재 착용 중인 꾸미기 1개(전역 단일). 미착용이면 생략.
+  equippedDecorationId?: string;
   ownedBackgroundIds: string[];
   appliedBackgroundId?: string;
 }
 
 export interface EquipResponse {
-  equippedDecorations: EquippedDecorationsDto;
+  equippedDecorationId?: string;
 }
 
 export interface PurchaseResponse {

--- a/src/services/ShopService.ts
+++ b/src/services/ShopService.ts
@@ -2,15 +2,11 @@ import prisma from '../utils/prisma';
 import {
   ShopCatalogItemDto,
   ShopInventoryResponse,
-  EquippedDecorationsDto,
   EquipResponse,
   PurchaseResponse,
-  DecorationSlot,
 } from '../models';
 import { Errors } from '../middleware/errorHandler';
 import { SHOP_CATALOG, CATALOG_BY_ID, DEFAULT_BACKGROUND_ID } from '../constants/shopCatalog';
-
-const VALID_SLOTS: DecorationSlot[] = ['head', 'back', 'feet'];
 
 export class ShopService {
   /**
@@ -46,11 +42,6 @@ export class ShopService {
     });
     const ownedDecorationIds = decorations.map((d) => d.itemId);
 
-    const equippedDecorations: EquippedDecorationsDto = {};
-    if (user.equippedHeadId) equippedDecorations.head = user.equippedHeadId;
-    if (user.equippedBackId) equippedDecorations.back = user.equippedBackId;
-    if (user.equippedFeetId) equippedDecorations.feet = user.equippedFeetId;
-
     // 배경 소유는 개인 단위(본인이 구매한 것만). 적용(appliedBackgroundId)은 그룹 공유지만,
     // 본인이 소유한 배경만 적용할 수 있으므로 ownedBackgroundIds 는 user 기준으로 집계한다.
     const ownedBackgroundIds: string[] = [DEFAULT_BACKGROUND_ID];
@@ -70,9 +61,10 @@ export class ShopService {
 
     const response: ShopInventoryResponse = {
       ownedDecorationIds,
-      equippedDecorations,
       ownedBackgroundIds,
     };
+    // 미착용(null/undefined)이면 키 자체를 생략.
+    if (user.equippedDecorationId) response.equippedDecorationId = user.equippedDecorationId;
     // appliedBackgroundId 가 null/undefined 면 키 자체를 생략.
     if (appliedBackgroundId) response.appliedBackgroundId = appliedBackgroundId;
     return response;
@@ -137,31 +129,17 @@ export class ShopService {
   }
 
   /**
-   * 꾸미기 장착/해제. itemId 미전달 시 해당 슬롯 해제(null).
-   * 장착 시 아이템 종류·슬롯 일치 + 소유 여부를 검증한다.
+   * 꾸미기 장착/해제 — 전역 단일. itemId 미전달 시 해제(null).
+   * 장착 시 아이템 종류(decoration) + 소유 여부만 검증한다. slot 은 더 이상
+   * 배타그룹 선택자가 아니므로 검증/매핑하지 않는다(단일 컬럼 덮어쓰기).
    */
-  async equipDecoration(
-    userId: string,
-    slot: DecorationSlot,
-    itemId?: string
-  ): Promise<EquipResponse> {
-    // 슬롯 값 검증을 항상 먼저(해제 경로 포함, 02-qa §3.4).
-    if (!VALID_SLOTS.includes(slot)) {
-      throw Errors.badRequest('유효하지 않은 슬롯입니다.');
-    }
-
+  async equipDecoration(userId: string, itemId?: string): Promise<EquipResponse> {
     const user = await this.resolveUser(userId);
-
-    const column =
-      slot === 'head' ? 'equippedHeadId' : slot === 'back' ? 'equippedBackId' : 'equippedFeetId';
 
     if (itemId) {
       const item = CATALOG_BY_ID[itemId];
       if (!item || item.kind !== 'decoration') {
-        throw Errors.badRequest('유효하지 않은 꾸미기 아이템입니다.');
-      }
-      if (item.slot !== slot) {
-        throw Errors.badRequest('아이템 슬롯이 일치하지 않습니다.');
+        throw Errors.badRequest('존재하지 않는 장식입니다.');
       }
       const owned = await prisma.userDecoration.findUnique({
         where: { userId_itemId: { userId: user.id, itemId } },
@@ -171,15 +149,10 @@ export class ShopService {
 
     const updated = await prisma.user.update({
       where: { id: user.id },
-      data: { [column]: itemId ?? null },
+      data: { equippedDecorationId: itemId ?? null },
     });
 
-    const equippedDecorations: EquippedDecorationsDto = {};
-    if (updated.equippedHeadId) equippedDecorations.head = updated.equippedHeadId;
-    if (updated.equippedBackId) equippedDecorations.back = updated.equippedBackId;
-    if (updated.equippedFeetId) equippedDecorations.feet = updated.equippedFeetId;
-
-    return { equippedDecorations };
+    return { equippedDecorationId: updated.equippedDecorationId ?? undefined };
   }
 
   /**

--- a/src/services/__tests__/ShopService.test.ts
+++ b/src/services/__tests__/ShopService.test.ts
@@ -50,9 +50,7 @@ const mockUser = {
   id: 'db-user-id',
   userId: 'kakao:123',
   familyId: 'family-id',
-  equippedHeadId: null as string | null,
-  equippedBackId: null as string | null,
-  equippedFeetId: null as string | null,
+  equippedDecorationId: null as string | null,
 };
 
 beforeEach(() => {
@@ -120,8 +118,7 @@ describe('ShopService.getInventory', () => {
     mockPrismaUserFindUnique.mockResolvedValue({
       ...mockUser,
       familyId: null,
-      equippedHeadId: 'deco_flower_crown',
-      equippedFeetId: 'deco_sneakers',
+      equippedDecorationId: 'deco_flower_crown',
     });
     mockPrismaUserDecorationFindMany.mockResolvedValue([
       { itemId: 'deco_flower_crown' },
@@ -129,10 +126,15 @@ describe('ShopService.getInventory', () => {
     ]);
 
     const inv = await service.getInventory('kakao:123');
-    expect(inv.equippedDecorations.head).toBe('deco_flower_crown');
-    expect(inv.equippedDecorations.feet).toBe('deco_sneakers');
-    expect(inv.equippedDecorations.back).toBeUndefined();
+    expect(inv.equippedDecorationId).toBe('deco_flower_crown');
     expect(inv.ownedDecorationIds).toEqual(['deco_flower_crown', 'deco_sneakers']);
+  });
+
+  it('미착용이면 equippedDecorationId 키가 생략된다', async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({ ...mockUser, familyId: null });
+
+    const inv = await service.getInventory('kakao:123');
+    expect(inv.equippedDecorationId).toBeUndefined();
   });
 
   it('본인이 소유한 배경 + 그룹 적용 배경을 포함한다', async () => {
@@ -228,46 +230,68 @@ describe('ShopService.purchase', () => {
 });
 
 describe('ShopService.equipDecoration', () => {
-  it('보유한 아이템을 장착하면 슬롯에 반영된다', async () => {
+  it('보유한 아이템을 장착하면 equippedDecorationId 에 반영된다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaUserDecorationFindUnique.mockResolvedValue({ id: 'owned' });
     mockPrismaUserUpdate.mockResolvedValue({
       ...mockUser,
-      equippedHeadId: 'deco_flower_crown',
+      equippedDecorationId: 'deco_flower_crown',
     });
 
-    const result = await service.equipDecoration('kakao:123', 'head', 'deco_flower_crown');
+    const result = await service.equipDecoration('kakao:123', 'deco_flower_crown');
     expect(mockPrismaUserUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { equippedHeadId: 'deco_flower_crown' } })
+      expect.objectContaining({ data: { equippedDecorationId: 'deco_flower_crown' } })
     );
-    expect(result.equippedDecorations.head).toBe('deco_flower_crown');
+    expect(result.equippedDecorationId).toBe('deco_flower_crown');
+  });
+
+  it('다른 아이템을 장착하면 이전 장착이 교체된다(단일 컬럼이 불변식을 보장)', async () => {
+    // 이미 deco_flower_crown(head) 착용 중인 상태에서 deco_sneakers(feet) 장착.
+    mockPrismaUserFindUnique.mockResolvedValue({
+      ...mockUser,
+      equippedDecorationId: 'deco_flower_crown',
+    });
+    mockPrismaUserDecorationFindUnique.mockResolvedValue({ id: 'owned' });
+    mockPrismaUserUpdate.mockResolvedValue({
+      ...mockUser,
+      equippedDecorationId: 'deco_sneakers',
+    });
+
+    const result = await service.equipDecoration('kakao:123', 'deco_sneakers');
+    // 단일 컬럼 덮어쓰기라 이전 장착은 별도 해제 없이 자동 교체된다.
+    expect(mockPrismaUserUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { equippedDecorationId: 'deco_sneakers' } })
+    );
+    expect(result.equippedDecorationId).toBe('deco_sneakers');
   });
 
   it('미보유 아이템 장착은 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
     mockPrismaUserDecorationFindUnique.mockResolvedValue(null);
     await expect(
-      service.equipDecoration('kakao:123', 'head', 'deco_flower_crown')
+      service.equipDecoration('kakao:123', 'deco_flower_crown')
     ).rejects.toThrow('보유하지 않은 아이템입니다.');
   });
 
-  it('슬롯이 일치하지 않으면 에러를 던진다', async () => {
+  it('존재하지 않는 itemId 는 에러를 던진다', async () => {
     mockPrismaUserFindUnique.mockResolvedValue(mockUser);
-    // deco_flower_crown 은 head 인데 feet 슬롯에 장착 시도
     await expect(
-      service.equipDecoration('kakao:123', 'feet', 'deco_flower_crown')
-    ).rejects.toThrow('슬롯이 일치하지 않습니다.');
+      service.equipDecoration('kakao:123', 'nope')
+    ).rejects.toThrow('존재하지 않는 장식입니다.');
   });
 
-  it('itemId 미전달 시 슬롯을 해제한다(null)', async () => {
-    mockPrismaUserFindUnique.mockResolvedValue({ ...mockUser, equippedHeadId: 'deco_flower_crown' });
-    mockPrismaUserUpdate.mockResolvedValue({ ...mockUser, equippedHeadId: null });
+  it('itemId 미전달 시 장착을 해제한다(null)', async () => {
+    mockPrismaUserFindUnique.mockResolvedValue({
+      ...mockUser,
+      equippedDecorationId: 'deco_flower_crown',
+    });
+    mockPrismaUserUpdate.mockResolvedValue({ ...mockUser, equippedDecorationId: null });
 
-    const result = await service.equipDecoration('kakao:123', 'head');
+    const result = await service.equipDecoration('kakao:123');
     expect(mockPrismaUserUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { equippedHeadId: null } })
+      expect.objectContaining({ data: { equippedDecorationId: null } })
     );
-    expect(result.equippedDecorations.head).toBeUndefined();
+    expect(result.equippedDecorationId).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 변경 (단순 컷오버 — 하위호환 없음, iOS 동시 배포 전제)
장식 착용을 **슬롯별 1개 → 전체 1개(global single)** 로 전환.

- `User`: `equippedHeadId/BackId/FeetId` 3컬럼 → **`equippedDecorationId String?`** 단일
- equip API: `POST /shop/decoration/equip` body `{slot,itemId}` → **`{itemId}`** (slot 배타 개념 제거, equip=단일 컬럼 덮어쓰기, itemId 생략=해제)
- 응답: `equippedDecorations{head,back,feet}` → **`equippedDecorationId?`** (inventory/equip 공통)
- DecorationSlot(head/back/feet)·풍선 slot·purchase 는 무변경 (placement/hand 슬롯은 2단계)

## 검증
tsc 0 · ShopService 테스트 25/25 · `npm run build` 성공(routes.ts /shop/* 5개 유지)

## ⚠️ 배포 (사용자)
- **iOS PR(rrheon/Mongle feat/deco-single-equip)과 동시 배포 필수** — API 계약 파괴적 변경.
- 마이그레이션: 신규 장식 기능이라 prod equip 데이터 미미 → **`prisma db push` 바로 실행(equip 상태 초기화 허용)** 가장 단순. 보존 원하면 `scripts/backfill-equipped-single.sql`(COALESCE) 을 중간 스키마에서 선실행.
- 순서: db push → `npm run build`(routes 재생성) → deploy:prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)