### PR TITLE
feat: 장식 손(hand) 슬롯 + 풍선 이동

### DIFF
--- a/src/constants/shopCatalog.ts
+++ b/src/constants/shopCatalog.ts
@@ -8,7 +8,7 @@
 
 export type ShopItemKind = 'background' | 'decoration';
 
-export type DecorationSlot = 'head' | 'back' | 'feet';
+export type DecorationSlot = 'head' | 'back' | 'feet' | 'hand';
 
 export interface ShopCatalogItem {
   id: string;
@@ -38,7 +38,7 @@ export const SHOP_CATALOG: ShopCatalogItem[] = [
   { id: 'deco_flower_crown', kind: 'decoration', name: '들꽃 화관', price: 50, slot: 'head', sortOrder: 1 },
   { id: 'deco_star_halo', kind: 'decoration', name: '별 후광', price: 50, slot: 'head', sortOrder: 2 },
   { id: 'deco_satin_ribbon', kind: 'decoration', name: '새틴 리본', price: 50, slot: 'head', sortOrder: 3 },
-  { id: 'deco_balloon_bunch', kind: 'decoration', name: '풍선 다발', price: 50, slot: 'head', sortOrder: 4 },
+  { id: 'deco_balloon_bunch', kind: 'decoration', name: '풍선 다발', price: 50, slot: 'hand', sortOrder: 4 },
   { id: 'deco_santa_hat', kind: 'decoration', name: '산타 모자', price: 50, slot: 'head', isSeasonal: true, sortOrder: 5 },
   { id: 'deco_angel_wings', kind: 'decoration', name: '천사 날개', price: 50, slot: 'back', sortOrder: 1 },
   { id: 'deco_cape', kind: 'decoration', name: '망토', price: 50, slot: 'back', sortOrder: 2 },

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -198,7 +198,7 @@ export interface FamilyAnswersResponse {
 // ============================================
 export type ShopItemKind = 'background' | 'decoration';
 
-export type DecorationSlot = 'head' | 'back' | 'feet';
+export type DecorationSlot = 'head' | 'back' | 'feet' | 'hand';
 
 export interface ShopCatalogItemDto {
   id: string;


### PR DESCRIPTION
## 손(hand) 슬롯 신설 — 서버
iOS 2단계(상점 장식 부착위치 세밀화 + 손 슬롯, rrheon/Mongle#141)와 짝.

### 변경 (2파일, 카탈로그 상수만)
- `src/models/index.ts` / `src/constants/shopCatalog.ts`: `DecorationSlot` 유니온 `'head'|'back'|'feet'` → `+ 'hand'`.
- `shopCatalog.ts`: 풍선(`deco_balloon_bunch`) slot `'head'` → `'hand'`.

### 영향
- **DB 무관**: slot은 카탈로그 상수(응답 직렬화 문자열). `UserDecoration`은 id만 저장 → `prisma db push` 불필요.
- 빌드 에러 0 (`tsoa spec-and-routes && tsc`).

### ⚠️ 배포 순서 (중요)
- 배포는 반드시 **`npm run build` 경유** — routes.ts/swagger가 gitignore 생성물이라 누락 시 미반영.
- **iOS 신버전을 먼저 또는 동시 배포.** 서버만 선배포 + 구버전 iOS면 구버전 `slot(from:)`에 hand 케이스가 없어 풍선이 모든 세그먼트에서 사라지는 리그레션 발생.

🤖 Generated with [Claude Code](https://claude.com/claude-code)